### PR TITLE
Clean shutdown of Poseidon and the application

### DIFF
--- a/container/src/main/java/com/flipkart/poseidon/BootstrapListener.java
+++ b/container/src/main/java/com/flipkart/poseidon/BootstrapListener.java
@@ -30,6 +30,8 @@ import org.trpr.platform.runtime.impl.event.BootstrapProgressMonitor;
 import static com.flipkart.poseidon.Poseidon.STARTUP_LOGGER;
 import static com.flipkart.poseidon.PoseidonContext.getBean;
 import static org.slf4j.LoggerFactory.getLogger;
+import static org.trpr.platform.runtime.common.RuntimeConstants.BOOTSTRAP_START_STATE;
+import static org.trpr.platform.runtime.common.RuntimeConstants.BOOTSTRAP_STOP_STATE;
 
 @Component
 public class BootstrapListener implements PlatformEventConsumer {
@@ -45,7 +47,7 @@ public class BootstrapListener implements PlatformEventConsumer {
         if (event.getSource() instanceof PlatformEvent) {
             PlatformEvent platformEvent = (PlatformEvent) event.getSource();
             if ("BootstrapMonitoredEvent".equals(platformEvent.getEventType())) {
-                if ("started".equals(platformEvent.getEventStatus())) {
+                if (BOOTSTRAP_START_STATE.equals(platformEvent.getEventStatus())) {
                     registerHystrixPlugins();
                     logger.info("\n************************************" +
                             "\n______ " +
@@ -56,7 +58,7 @@ public class BootstrapListener implements PlatformEventConsumer {
                             "\n\\_|    Now starting Poseidon..." +
                             "\n************************************");
                     startPoseidon();
-                } else if ("stopped".equals(platformEvent.getEventStatus())) {
+                } else if (BOOTSTRAP_STOP_STATE.equals(platformEvent.getEventStatus())) {
                     stopPoseidon();
                 }
             }

--- a/container/src/main/java/com/flipkart/poseidon/BootstrapListener.java
+++ b/container/src/main/java/com/flipkart/poseidon/BootstrapListener.java
@@ -27,13 +27,14 @@ import org.trpr.platform.core.spi.event.PlatformEventConsumer;
 import org.trpr.platform.model.event.PlatformEvent;
 import org.trpr.platform.runtime.impl.event.BootstrapProgressMonitor;
 
+import static com.flipkart.poseidon.Poseidon.STARTUP_LOGGER;
 import static com.flipkart.poseidon.PoseidonContext.getBean;
 import static org.slf4j.LoggerFactory.getLogger;
 
 @Component
 public class BootstrapListener implements PlatformEventConsumer {
 
-    private static final Logger logger = getLogger(BootstrapListener.class);
+    private static final Logger logger = getLogger(STARTUP_LOGGER);
 
     public void setBootstrapProgressMonitor(BootstrapProgressMonitor bootstrapProgressMonitor) {
         bootstrapProgressMonitor.addBootstrapEventListener(this);
@@ -42,8 +43,9 @@ public class BootstrapListener implements PlatformEventConsumer {
     @Override
     public void onApplicationEvent(PlatformApplicationEvent event) {
         if (event.getSource() instanceof PlatformEvent) {
-            if (((PlatformEvent) event.getSource()).getEventType().equals("BootstrapMonitoredEvent")) {
-                if (((PlatformEvent) event.getSource()).getEventStatus().equals("started")) {
+            PlatformEvent platformEvent = (PlatformEvent) event.getSource();
+            if ("BootstrapMonitoredEvent".equals(platformEvent.getEventType())) {
+                if ("started".equals(platformEvent.getEventStatus())) {
                     registerHystrixPlugins();
                     logger.info("\n************************************" +
                             "\n______ " +
@@ -54,6 +56,8 @@ public class BootstrapListener implements PlatformEventConsumer {
                             "\n\\_|    Now starting Poseidon..." +
                             "\n************************************");
                     startPoseidon();
+                } else if ("stopped".equals(platformEvent.getEventStatus())) {
+                    stopPoseidon();
                 }
             }
         }
@@ -69,6 +73,10 @@ public class BootstrapListener implements PlatformEventConsumer {
 
     private void startPoseidon() {
         new ClassPathXmlApplicationContext("web.xml");
-        getBean(Poseidon.class).run();
+        getBean(Poseidon.class).start();
+    }
+
+    private void stopPoseidon() {
+        getBean(Poseidon.class).stop();
     }
 }

--- a/container/src/main/java/com/flipkart/poseidon/Poseidon.java
+++ b/container/src/main/java/com/flipkart/poseidon/Poseidon.java
@@ -149,7 +149,8 @@ public class Poseidon {
             server.start();
             logger.info("*** Poseidon started ***");
         } catch (Exception e) {
-            logger.error("Unable to start server.", e);
+            logger.error("Unable to start Poseidon.", e);
+            throw new RuntimeException("Unable to start Poseidon", e);
         }
     }
 

--- a/container/src/main/java/com/flipkart/poseidon/api/Application.java
+++ b/container/src/main/java/com/flipkart/poseidon/api/Application.java
@@ -33,4 +33,6 @@ public interface Application {
     void handleRequest(PoseidonRequest req, PoseidonResponse resp) throws ElementNotFoundException, BadRequestException, ProcessingException, InternalErrorException;
 
     MediaType getDefaultMediaType();
+
+    default void stop() {}
 }

--- a/container/src/main/java/com/flipkart/poseidon/core/PoseidonServlet.java
+++ b/container/src/main/java/com/flipkart/poseidon/core/PoseidonServlet.java
@@ -60,17 +60,11 @@ public class PoseidonServlet extends HttpServlet {
 
     private static final Logger logger = getLogger(PoseidonServlet.class);
     private final Application application;
-    private final ExecutorService datasourceTPE;
-    private final ExecutorService filterTPE;
     private final Configuration configuration;
 
-    public PoseidonServlet(Application application, Configuration configuration, ExecutorService datasourceTPE, ExecutorService filterTPE) {
+    public PoseidonServlet(Application application, Configuration configuration) {
         this.application = application;
         this.configuration = configuration;
-        this.datasourceTPE = datasourceTPE;
-        this.filterTPE = filterTPE;
-
-        application.init(datasourceTPE, filterTPE);
     }
 
     @Override

--- a/core/src/main/java/com/flipkart/poseidon/jmx/PoseidonJMXInvoker.java
+++ b/core/src/main/java/com/flipkart/poseidon/jmx/PoseidonJMXInvoker.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Flipkart Internet, pvt ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.flipkart.poseidon.jmx;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import java.io.EOFException;
+
+/**
+ * A standalone program to invoke mbean operations over JMX on a running Poseidon process.
+ * Can be used to shutdown a Poseidon application cleanly.
+ * Ex: PoseidonJMXInvoker &lt;host&gt; &lt;port&gt; destroy.
+ *
+ * Created by mohan.pandian on 12/07/16.
+ */
+public class PoseidonJMXInvoker {
+    // BootstrapModelMBeanExporter.MBEAN_NAME is private in Trooper.
+    private static final String MBEAN_NAME = "spring.application:type=Trooper,application=Runtime,name=Bootstrap-poseidon";
+
+    public static void main(String[] args) {
+        if (args.length < 3) {
+            System.err.println(PoseidonJMXInvoker.class.getSimpleName() + " <host> <port> <operation>");
+            System.exit(-1);
+        }
+
+        final String CONNECT_STRING = args[0] + ":" + args[1];
+        final String OPERATION = args[2];
+        try {
+            System.out.println("Running " + OPERATION + " over JMX on " + CONNECT_STRING);
+
+            JMXServiceURL url = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://" + CONNECT_STRING + "/jmxrmi");
+            MBeanServerConnection connection = JMXConnectorFactory.connect(url).getMBeanServerConnection();
+            connection.invoke(ObjectName.getInstance(MBEAN_NAME), OPERATION, null, null);
+        } catch (Exception e) {
+            if (!(ExceptionUtils.getRootCause(e) instanceof EOFException && "destroy".equals(OPERATION))) {
+                e.printStackTrace();
+                System.exit(-1);
+            }
+        }
+        System.out.println(OPERATION + " successful over JMX on " + CONNECT_STRING);
+    }
+}


### PR DESCRIPTION
1. Trooper already supports destroy() operation through JMX MBean. It sends "stopped" event before stopping itself (similar to "started" event which is already subscribed by BootstrapListener). We listen for this event and then call stop() on application, thread pools and the jetty server. After which trooper will shutdown all handlers, admin jetty instance etc and exit.
2. All startup and shutdown logs are collated through a common logger so that startup/shutdown logs can be redirected to a different file.
3. A standalone java program to invoke destroy on trooper's MBean over JMX (which can be used from startup scripts)
4. Exceptions during application init() or jetty start() etc would be thrown and hence process won't start