### PR TITLE
Send X-Timestamp header for all HTTP services

### DIFF
--- a/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/HttpConnectionPool.java
+++ b/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/HttpConnectionPool.java
@@ -60,6 +60,7 @@ public class HttpConnectionPool {
     private static final String CONTENT_ENCODING = "Content-Encoding";
     private static final String ACCEPT_ENCODING = "Accept-Encoding";
     private static final String COMPRESSION_TYPE = "gzip";
+    private static final String TIMESTAMP_HEADER = "X-Timestamp";
 
     /** socket connection timeToLive in seconds */
     private int timeToLiveInSecs = -1;
@@ -245,6 +246,9 @@ public class HttpConnectionPool {
         if (processQueue.tryAcquire()) {
             HttpResponse response;
             try {
+                // Inject timestamp in milliseconds just before sending request on wire.
+                // This will help in measuring latencies between client and server.
+                request.addHeader(TIMESTAMP_HEADER, String.valueOf(System.currentTimeMillis()));
                 response = client.execute(request);
             } catch (Exception e) {
                 logger.error("Connections: {} AvailableRequests: {}", ((PoolingClientConnectionManager) this.client.getConnectionManager()).getTotalStats(), processQueue.availablePermits());


### PR DESCRIPTION
Idea is to send the current time in milliseconds in a HTTP header to all HTTP based services. This should be kept closer to the place where the requests actually goes over wire (to remove client side latencies itself).

So this can't be done from datasource, service client or even HttpTaskHandler (as there are semaphores involved in connection pool). Hence moved this inside connection pool, after acquiring semaphore which is the closest place we could get before sending actual http request