### PR TITLE
MDC context passing over threads

### DIFF
--- a/container/src/main/java/com/flipkart/poseidon/Poseidon.java
+++ b/container/src/main/java/com/flipkart/poseidon/Poseidon.java
@@ -251,7 +251,7 @@ public class Poseidon {
 
     private void addFilters(ServletContextHandler servletContextHandler) {
         // RequestContext is required in other filters, hence set it up first
-        servletContextHandler.addFilter(new FilterHolder(new HystrixContextFilter()), "/*", EnumSet.of(REQUEST));
+        servletContextHandler.addFilter(new FilterHolder(new HystrixContextFilter(configuration)), "/*", EnumSet.of(REQUEST));
         // Set up distributed tracing filter
         ServletTraceFilter servletTraceFilter = ServletTraceFilterBuilder.build(configuration);
         if (servletTraceFilter != null) {

--- a/container/src/main/java/com/flipkart/poseidon/core/PoseidonServlet.java
+++ b/container/src/main/java/com/flipkart/poseidon/core/PoseidonServlet.java
@@ -18,11 +18,7 @@ package com.flipkart.poseidon.core;
 
 import com.flipkart.poseidon.api.Application;
 import com.flipkart.poseidon.api.Configuration;
-import com.flipkart.poseidon.api.HeaderConfiguration;
-import com.flipkart.poseidon.constants.RequestConstants;
 import com.flipkart.poseidon.exception.DataSourceException;
-import com.flipkart.poseidon.serviceclients.ServiceContext;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.net.MediaType;
 import flipkart.lego.api.exceptions.BadRequestException;
 import flipkart.lego.api.exceptions.ElementNotFoundException;
@@ -44,14 +40,11 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
 
 import static com.flipkart.poseidon.constants.RequestConstants.*;
-import static com.flipkart.poseidon.serviceclients.ServiceClientConstants.HEADERS;
 import static javax.servlet.http.HttpServletResponse.*;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.http.HttpMethod.*;
@@ -103,9 +96,6 @@ public class PoseidonServlet extends HttpServlet {
     }
 
     protected void doRequest(HttpMethod method, HttpServletRequest httpRequest, HttpServletResponse httpResponse) throws IOException {
-        setRequestContext(httpRequest);
-        setServiceContext(httpRequest);
-
         PoseidonRequest request = new PoseidonRequest(httpRequest);
         request.setAttribute(METHOD, method);
 
@@ -139,33 +129,6 @@ public class PoseidonServlet extends HttpServlet {
         } catch (Throwable exception) {
             internalError(response, httpResponse, exception);
         }
-    }
-
-    private void setRequestContext(HttpServletRequest httpServletRequest) {
-        RequestContext.set(METHOD, httpServletRequest.getMethod());
-        RequestContext.set(SOURCE_ADDRESS, httpServletRequest.getRemoteAddr());
-    }
-
-    private void setServiceContext(HttpServletRequest httpServletRequest) {
-        if (configuration.getHeadersConfiguration() == null || configuration.getHeadersConfiguration().getGlobalHeaders() == null) {
-            return;
-        }
-
-        Map<String, String> headers = new HashMap<>();
-        for (HeaderConfiguration headerConfiguration : configuration.getHeadersConfiguration().getGlobalHeaders()) {
-            String value = httpServletRequest.getHeader(headerConfiguration.getName());
-            if (value == null) {
-                value = headerConfiguration.getDefaultValue();
-            }
-
-            if (value != null) {
-                headers.put(headerConfiguration.getName(), value);
-            }
-        }
-
-        ImmutableMap<String, String> immutableHeaders = ImmutableMap.copyOf(headers);
-        ServiceContext.set(HEADERS, immutableHeaders);
-        RequestContext.set(RequestConstants.HEADERS, immutableHeaders);
     }
 
     private void handleFileUpload(PoseidonRequest request, HttpServletRequest httpRequest) throws IOException {

--- a/core/src/main/java/com/flipkart/poseidon/legoset/ContextInducedBlock.java
+++ b/core/src/main/java/com/flipkart/poseidon/legoset/ContextInducedBlock.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2016 Flipkart Internet, pvt ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.flipkart.poseidon.legoset;
+
+import com.flipkart.poseidon.core.RequestContext;
+import com.flipkart.poseidon.serviceclients.ServiceContext;
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ServerSpan;
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
+import flipkart.lego.api.entities.Request;
+import flipkart.lego.api.helpers.Identifiable;
+import org.slf4j.MDC;
+
+import java.util.Map;
+
+import static com.flipkart.poseidon.tracing.TraceHelper.endTrace;
+import static com.flipkart.poseidon.tracing.TraceHelper.startTrace;
+
+/**
+ *
+ * Induces all request contexts (like contexts used by Hystrix, Brave's DT, our own RequestContext etc)
+ * into DataSource/Filter threads from parent threads
+ *
+ * Created by mohan.pandian on 04/08/16.
+ */
+public abstract class ContextInducedBlock {
+    /* Either data source or filter */
+    private final Identifiable identifiable;
+
+    /* Poseidon's request context from parent thread */
+    private final Map<String, Object> parentContext;
+
+    /* Poseidon's service context from parent thread */
+    private final Map<String, Object> parentServiceContext;
+
+    /* Hystrix request context from parent thread */
+    private final HystrixRequestContext parentThreadState;
+
+    /* MDC request context from parent thread */
+    private final Map<String, String> mdcContext;
+
+    /* Brave's zipkin request context from parent thread */
+    private final ServerSpan serverSpan;
+
+    /* Hystrix request context of current thread */
+    private HystrixRequestContext existingState;
+
+    /* Whether the filter or datasource was executed without exceptions */
+    protected boolean success = false;
+
+    /* Stores parent's contexts */
+    protected ContextInducedBlock(Identifiable identifiable) {
+        this.identifiable = identifiable;
+        parentContext = RequestContext.getContextMap();
+        parentServiceContext = ServiceContext.getContextMap();
+        parentThreadState = HystrixRequestContext.getContextForCurrentThread();
+        mdcContext = MDC.getCopyOfContextMap();
+        serverSpan = Brave.getServerSpanThreadBinder().getCurrentServerSpan();
+    }
+
+    /* Passes parent's contexts to DS/filter contexts */
+    protected void initAllContext(Request request) {
+        existingState = HystrixRequestContext.getContextForCurrentThread();
+        RequestContext.initialize(parentContext);
+        ServiceContext.initialize(parentServiceContext);
+        HystrixRequestContext.setContextOnCurrentThread(parentThreadState);
+        if (mdcContext != null) {
+            MDC.setContextMap(mdcContext);
+        }
+        // Parent thread span info is passed onto filter thread using Brave's ThreadLocal implementation
+        if (serverSpan != null && serverSpan.getSpan() != null) {
+            Brave.getServerSpanThreadBinder().setCurrentSpan(serverSpan);
+        }
+        startTrace(identifiable, request);
+    }
+
+    /* Clears DS/filter contexts */
+    protected void shutdownAllContext() {
+        endTrace(identifiable, success);
+        RequestContext.shutDown();
+        ServiceContext.shutDown();
+        HystrixRequestContext.setContextOnCurrentThread(existingState);
+        MDC.clear();
+        Brave.getServerSpanThreadBinder().setCurrentSpan(null);
+    }
+}

--- a/core/src/main/java/com/flipkart/poseidon/legoset/ContextInducedDataSource.java
+++ b/core/src/main/java/com/flipkart/poseidon/legoset/ContextInducedDataSource.java
@@ -16,81 +16,37 @@
 
 package com.flipkart.poseidon.legoset;
 
-import com.flipkart.poseidon.core.RequestContext;
-import com.flipkart.poseidon.serviceclients.ServiceContext;
-import com.github.kristofa.brave.Brave;
-import com.github.kristofa.brave.ServerSpan;
-import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
 import flipkart.lego.api.entities.DataSource;
 import flipkart.lego.api.entities.DataType;
 import flipkart.lego.api.entities.Request;
-import org.slf4j.MDC;
 
 import java.util.List;
-import java.util.Map;
-
-import static com.flipkart.poseidon.tracing.TraceHelper.endTrace;
-import static com.flipkart.poseidon.tracing.TraceHelper.startTrace;
 
 /*
  * Induces all request contexts (like contexts used by Hystrix, Brave's DT, our own RequestContext)
  * into DataSource threads from Jetty threads
  */
-public class ContextInducedDataSource implements DataSource {
+public class ContextInducedDataSource extends ContextInducedBlock implements DataSource {
 
     private final DataSource dataSource;
     private final Request request;
-    private final Map<String, Object> parentContext;
-    private final Map<String, Object> parentServiceContext;
-    private final HystrixRequestContext parentThreadState;
-    private final Map<String, String> mdcContext;
-    private final ServerSpan serverSpan;
 
     public ContextInducedDataSource(DataSource dataSource, Request request) {
+        super(dataSource);
         this.dataSource = dataSource;
         this.request = request;
-        parentContext = RequestContext.getContextMap();
-        parentServiceContext = ServiceContext.getContextMap();
-        parentThreadState = HystrixRequestContext.getContextForCurrentThread();
-        mdcContext = MDC.getCopyOfContextMap();
-        serverSpan = Brave.getServerSpanThreadBinder().getCurrentServerSpan();
     }
 
     @Override
     public DataType call() throws Exception {
-        HystrixRequestContext existingState = HystrixRequestContext.getContextForCurrentThread();
-        boolean success = false;
         try {
-            initAllContext();
+            initAllContext(request);
             DataType dataType = dataSource.call();
             success = true;
             return dataType;
         } finally {
-            shutdownAllContext(existingState, success);
+            shutdownAllContext();
         }
-    }
-
-    private void initAllContext() {
-        RequestContext.initialize(parentContext);
-        ServiceContext.initialize(parentServiceContext);
-        HystrixRequestContext.setContextOnCurrentThread(parentThreadState);
-        if (mdcContext != null) {
-            MDC.setContextMap(mdcContext);
-        }
-        // Parent thread span info is passed onto filter thread using Brave's ThreadLocal implementation
-        if (serverSpan != null && serverSpan.getSpan() != null) {
-            Brave.getServerSpanThreadBinder().setCurrentSpan(serverSpan);
-        }
-        startTrace(dataSource, request);
-    }
-
-    private void shutdownAllContext(HystrixRequestContext existingState, boolean success) {
-        endTrace(dataSource, success);
-        RequestContext.shutDown();
-        ServiceContext.shutDown();
-        HystrixRequestContext.setContextOnCurrentThread(existingState);
-        MDC.clear();
-        Brave.getServerSpanThreadBinder().setCurrentSpan(null);
     }
 
     @Override

--- a/core/src/main/java/com/flipkart/poseidon/legoset/ContextInducedFilter.java
+++ b/core/src/main/java/com/flipkart/poseidon/legoset/ContextInducedFilter.java
@@ -16,95 +16,50 @@
 
 package com.flipkart.poseidon.legoset;
 
-import com.flipkart.poseidon.core.RequestContext;
-import com.flipkart.poseidon.serviceclients.ServiceContext;
-import com.github.kristofa.brave.Brave;
-import com.github.kristofa.brave.ServerSpan;
-import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
 import flipkart.lego.api.entities.Filter;
 import flipkart.lego.api.entities.Request;
 import flipkart.lego.api.entities.Response;
 import flipkart.lego.api.exceptions.BadRequestException;
 import flipkart.lego.api.exceptions.InternalErrorException;
 import flipkart.lego.api.exceptions.ProcessingException;
-import org.slf4j.MDC;
 
 import java.util.List;
-import java.util.Map;
-
-import static com.flipkart.poseidon.tracing.TraceHelper.endTrace;
-import static com.flipkart.poseidon.tracing.TraceHelper.startTrace;
 
 /*
  * Induces all request contexts (like contexts used by Hystrix, Brave's DT, our own RequestContext)
  * into DataSource threads from Jetty threads
  */
-public class ContextInducedFilter implements Filter {
+public class ContextInducedFilter extends ContextInducedBlock implements Filter {
 
     private final Filter filter;
-    private final Map<String, Object> parentContext;
-    private final Map<String, Object> parentServiceContext;
-    private final HystrixRequestContext parentThreadState;
-    private final Map<String, String> mdcContext;
-    private final ServerSpan serverSpan;
 
     public ContextInducedFilter(Filter filter) {
+        super(filter);
         this.filter = filter;
-        parentContext = RequestContext.getContextMap();
-        parentServiceContext = ServiceContext.getContextMap();
-        parentThreadState = HystrixRequestContext.getContextForCurrentThread();
-        mdcContext = MDC.getCopyOfContextMap();
-        serverSpan = Brave.getServerSpanThreadBinder().getCurrentServerSpan();
     }
 
     @Override
     public void filterRequest(Request request, Response response) throws InternalErrorException, BadRequestException, ProcessingException {
-        HystrixRequestContext existingState = HystrixRequestContext.getContextForCurrentThread();
-        boolean success = false;
         try {
-            initAllContext();
+            // We don't want to trace requests in filter traces. Hence pass null for request.
+            initAllContext(null);
             filter.filterRequest(request, response);
             success = true;
         } finally {
-            shutdownAllContext(existingState, success);
+            shutdownAllContext();
         }
     }
 
     @Override
     public void filterResponse(Request request, Response response) throws InternalErrorException, BadRequestException, ProcessingException {
-        HystrixRequestContext existingState = HystrixRequestContext.getContextForCurrentThread();
-        boolean success = false;
         try {
-            initAllContext();
+            // We don't want to trace responses in filter traces. Hence pass null for request.
+            initAllContext(null);
             filter.filterResponse(request, response);
             success = true;
         } finally {
-            shutdownAllContext(existingState, success);
+            shutdownAllContext();
         }
-    }
-
-    private void initAllContext() {
-        RequestContext.initialize(parentContext);
-        ServiceContext.initialize(parentServiceContext);
-        HystrixRequestContext.setContextOnCurrentThread(parentThreadState);
-        if (mdcContext != null) {
-            MDC.setContextMap(mdcContext);
-        }
-        // Parent thread span info is passed onto filter thread using Brave's ThreadLocal implementation
-        if (serverSpan != null && serverSpan.getSpan() != null) {
-            Brave.getServerSpanThreadBinder().setCurrentSpan(serverSpan);
-        }
-        // We don't want to trace responses in filter traces
-        startTrace(filter);
-    }
-
-    private void shutdownAllContext(HystrixRequestContext existingState, boolean success) {
-        endTrace(filter, success);
-        RequestContext.shutDown();
-        ServiceContext.shutDown();
-        HystrixRequestContext.setContextOnCurrentThread(existingState);
-        MDC.clear();
-        Brave.getServerSpanThreadBinder().setCurrentSpan(null);
     }
 
     @Override


### PR DESCRIPTION
Poseidon doesn't pass MDC context between jetty, datasource and filter threads making it impossible to log MDC thread local variables from applications.

Poseidon has to pass MDC context between all the threads that it starts and also has to initialize request context, service context in jetty filter (currently is done in servlet after filters)
