### PR TITLE
Avoid serialization and de-serialization within runtime

### DIFF
--- a/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/HandlerConstants.java
+++ b/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/HandlerConstants.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Flipkart Internet, pvt ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.flipkart.poseidon.handlers.http;
+
+/**
+ * Constants used across http-handler and re-used in service-clients-core
+ * <p/>
+ * Created by mohan.pandian on 10/09/16.
+ */
+public class HandlerConstants {
+    public static final String HTTP_URI = "uri";
+    public static final String HTTP_METHOD = "method";
+    public static final String HTTP_HEADERS = "headers";
+
+    public static final String X_CACHE_REQUEST = "X-Cache-Request";
+}

--- a/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/SinglePoolHttpTaskHandler.java
+++ b/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/SinglePoolHttpTaskHandler.java
@@ -135,13 +135,13 @@ public class SinglePoolHttpTaskHandler extends RequestCacheableHystrixTaskHandle
         Map<String,String> requestHeaders = getRequestHeaders(params);
 
         try {
-            HttpRequestBase request = this.pool.createHttpRequest(params.get(HTTP_URI).toString(), data, requestHeaders, params.get(HTTP_METHOD).toString());
+            HttpRequestBase request = this.pool.createHttpRequest((String) params.get(HTTP_URI), data, requestHeaders, (String) params.get(HTTP_METHOD));
             HttpResponse httpResponse =  this.pool.execute(request);
 
             return  new TaskResult<T>(true, null, ((HttpResponseDecoder<T>) decoder).decode(httpResponse));
         }
         catch (Exception e) {
-            handleException(e, params.get(HTTP_URI).toString(), params.get(HTTP_METHOD).toString());
+            handleException(e, (String) params.get(HTTP_URI), (String) params.get(HTTP_METHOD));
         }
         return null;
     }
@@ -163,15 +163,15 @@ public class SinglePoolHttpTaskHandler extends RequestCacheableHystrixTaskHandle
 
         Map<String,String> requestHeaders = getRequestHeaders(params);
 
-        if(params.get("executeAsync") != null && Boolean.parseBoolean(params.get("executeAsync").toString())){
+        if(params.get("executeAsync") != null && Boolean.parseBoolean((String) params.get("executeAsync"))){
             return processAsyncHttpRequest(taskContext,command,params,(byte[]) data);
         }
         TaskResult result;
         try {
-            result  = handleHttpResponse(makeRequest(params.get(HTTP_METHOD).toString(),params.get(HTTP_URI).toString(), (byte[]) data, requestHeaders));
+            result  = handleHttpResponse(makeRequest((String) params.get(HTTP_METHOD), (String) params.get(HTTP_URI), (byte[]) data, requestHeaders));
         }
         catch (Exception e) {
-            result =  handleException(e, params.get(HTTP_URI).toString(), params.get(HTTP_METHOD).toString());
+            result =  handleException(e, (String) params.get(HTTP_URI), (String) params.get(HTTP_METHOD));
         }
         return result;
     }
@@ -214,13 +214,15 @@ public class SinglePoolHttpTaskHandler extends RequestCacheableHystrixTaskHandle
 
         if (params != null ) {
             if(params.containsKey("requestID")) {
-                requestHeaders.put("X-Request-ID",params.get("requestID").toString());
+                requestHeaders.put("X-Request-ID", (String) params.get("requestID"));
             }
             if(params.containsKey(HTTP_HEADERS)) {
                 Map<String, Object> customHeaders = (Map<String, Object>) params.get(HTTP_HEADERS);
                 if (customHeaders != null) {
                     for (Map.Entry<String, Object> entry: customHeaders.entrySet()) {
-                        requestHeaders.put(entry.getKey(), entry.getValue().toString());
+                        if (entry.getKey() != null && entry.getValue() != null) {
+                            requestHeaders.put(entry.getKey(), entry.getValue().toString());
+                        }
                     }
                 }
             }
@@ -265,7 +267,7 @@ public class SinglePoolHttpTaskHandler extends RequestCacheableHystrixTaskHandle
                 return handleHttpResponse(getHttpResponseData(response));
             }
         } catch (Exception e){
-            handleException(e,params.get(HTTP_URI).toString(),params.get(HTTP_METHOD).toString());
+            handleException(e, (String) params.get(HTTP_URI), (String) params.get(HTTP_METHOD));
         }
         return new TaskResult(false,null,null);
     }

--- a/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/SinglePoolHttpTaskHandler.java
+++ b/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/SinglePoolHttpTaskHandler.java
@@ -40,6 +40,12 @@ import java.util.Map;
 
 import static com.google.common.hash.Hashing.murmur3_32;
 
+import static com.flipkart.poseidon.handlers.http.HandlerConstants.HTTP_HEADERS;
+import static com.flipkart.poseidon.handlers.http.HandlerConstants.HTTP_METHOD;
+import static com.flipkart.poseidon.handlers.http.HandlerConstants.HTTP_URI;
+import static com.flipkart.poseidon.handlers.http.HandlerConstants.X_CACHE_REQUEST;
+
+
 public class SinglePoolHttpTaskHandler extends RequestCacheableHystrixTaskHandler {
 
     /** Log instance of this class */
@@ -123,19 +129,19 @@ public class SinglePoolHttpTaskHandler extends RequestCacheableHystrixTaskHandle
     @Override
     public <T, S> TaskResult<T> execute(TaskContext taskContext, String command,
                                      TaskRequestWrapper<S> taskRequestWrapper,Decoder<T> decoder) throws RuntimeException {
-        Map<String,String> params = taskRequestWrapper.getParams();
+        Map<String, Object> params = taskRequestWrapper.getParams();
         byte[] data = (byte[]) taskRequestWrapper.getData();
 
         Map<String,String> requestHeaders = getRequestHeaders(params);
 
         try {
-            HttpRequestBase request = this.pool.createHttpRequest(params.get("uri"), data, requestHeaders, params.get("method"));
+            HttpRequestBase request = this.pool.createHttpRequest(params.get(HTTP_URI).toString(), data, requestHeaders, params.get(HTTP_METHOD).toString());
             HttpResponse httpResponse =  this.pool.execute(request);
 
             return  new TaskResult<T>(true, null, ((HttpResponseDecoder<T>) decoder).decode(httpResponse));
         }
         catch (Exception e) {
-            handleException(e, params.get("uri"), params.get("method"));
+            handleException(e, params.get(HTTP_URI).toString(), params.get(HTTP_METHOD).toString());
         }
         return null;
     }
@@ -153,19 +159,19 @@ public class SinglePoolHttpTaskHandler extends RequestCacheableHystrixTaskHandle
      * @return
      */
     @Override
-    public <T, S> TaskResult<T> execute(TaskContext taskContext, String command, Map<String, String> params, S data) {
+    public <T, S> TaskResult<T> execute(TaskContext taskContext, String command, Map<String, Object> params, S data) {
 
         Map<String,String> requestHeaders = getRequestHeaders(params);
 
-        if(params.get("executeAsync") != null && Boolean.parseBoolean(params.get("executeAsync"))){
+        if(params.get("executeAsync") != null && Boolean.parseBoolean(params.get("executeAsync").toString())){
             return processAsyncHttpRequest(taskContext,command,params,(byte[]) data);
         }
         TaskResult result;
         try {
-            result  = handleHttpResponse(makeRequest(params.get("method"),params.get("uri"), (byte[]) data, requestHeaders));
+            result  = handleHttpResponse(makeRequest(params.get(HTTP_METHOD).toString(),params.get(HTTP_URI).toString(), (byte[]) data, requestHeaders));
         }
         catch (Exception e) {
-            result =  handleException(e, params.get("uri"), params.get("method"));
+            result =  handleException(e, params.get(HTTP_URI).toString(), params.get(HTTP_METHOD).toString());
         }
         return result;
     }
@@ -176,20 +182,20 @@ public class SinglePoolHttpTaskHandler extends RequestCacheableHystrixTaskHandle
             return null;
         }
 
-        boolean hasURI = requestParams.containsKey("uri");
-        boolean isGet = "GET".equalsIgnoreCase(requestParams.get("method"));
-        boolean askedTobeCached = "true".equalsIgnoreCase(requestParams.get("X-Cache-Request"));
+        boolean hasURI = requestParams.containsKey(HTTP_URI);
+        boolean isGet = "GET".equalsIgnoreCase(requestParams.get(HTTP_METHOD));
+        boolean askedTobeCached = "true".equalsIgnoreCase(requestParams.get(X_CACHE_REQUEST));
         if (!hasURI || (!isGet && !askedTobeCached)) {
             return null;
         }
 
-        String cacheKey = requestParams.get("uri") + (data != null ? new String((byte[]) data) : "");
+        String cacheKey = requestParams.get(HTTP_URI) + (data != null ? new String((byte[]) data) : "");
         return murmur3_32().hashString(cacheKey, Charsets.UTF_16LE).toString();
     }
 
     /** interface method implementation */
     @Override
-    public <T, S> TaskResult<T> getFallBack(TaskContext taskContext, String command, Map<String, String> params, S data) {
+    public <T, S> TaskResult<T> getFallBack(TaskContext taskContext, String command, Map<String, Object> params, S data) {
         return null;
     }
 
@@ -203,19 +209,19 @@ public class SinglePoolHttpTaskHandler extends RequestCacheableHystrixTaskHandle
      *
      * @param params
      */
-    protected Map<String,String> getRequestHeaders(Map<String,String> params) {
-        Map<String,String> requestHeaders = new HashMap<String, String>();
+    protected Map<String,String> getRequestHeaders(Map<String,Object> params) {
+        Map<String,String> requestHeaders = new HashMap<>();
 
         if (params != null ) {
             if(params.containsKey("requestID")) {
-                requestHeaders.put("X-Request-ID",params.get("requestID"));
+                requestHeaders.put("X-Request-ID",params.get("requestID").toString());
             }
-            if(params.containsKey("headers")) {
-                try{
-                    Map<String,String> customHeaders = objectMapper.readValue(params.get("headers"), Map.class);
-                    requestHeaders.putAll(customHeaders);
-                } catch (Exception e) {
-                    logger.info("Error while parsing custom header" + e.getMessage());
+            if(params.containsKey(HTTP_HEADERS)) {
+                Map<String, Object> customHeaders = (Map<String, Object>) params.get(HTTP_HEADERS);
+                if (customHeaders != null) {
+                    for (Map.Entry<String, Object> entry: customHeaders.entrySet()) {
+                        requestHeaders.put(entry.getKey(), entry.getValue().toString());
+                    }
                 }
             }
         }
@@ -246,7 +252,7 @@ public class SinglePoolHttpTaskHandler extends RequestCacheableHystrixTaskHandle
      * @param data
      * @return
      */
-    protected  TaskResult processAsyncHttpRequest(TaskContext taskContext,String command, Map<String,String> params, byte[] data){
+    protected  TaskResult processAsyncHttpRequest(TaskContext taskContext,String command, Map<String,Object> params, byte[] data){
         HttpResponse response = null;
         try{
             if(!enableAsyncExecution){
@@ -259,7 +265,7 @@ public class SinglePoolHttpTaskHandler extends RequestCacheableHystrixTaskHandle
                 return handleHttpResponse(getHttpResponseData(response));
             }
         } catch (Exception e){
-            handleException(e,params.get("uri"),params.get("method"));
+            handleException(e,params.get(HTTP_URI).toString(),params.get(HTTP_METHOD).toString());
         }
         return new TaskResult(false,null,null);
     }

--- a/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/oauth/OAuthPoolHttpTaskHandler.java
+++ b/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/oauth/OAuthPoolHttpTaskHandler.java
@@ -54,7 +54,7 @@ public class OAuthPoolHttpTaskHandler extends SinglePoolHttpTaskHandler {
      * @param params
      */
     @Override
-    protected Map<String, String> getRequestHeaders(Map<String, String> params) {
+    protected Map<String, String> getRequestHeaders(Map<String, Object> params) {
         Map<String, String> requestHeaders = super.getRequestHeaders(params);
         requestHeaders.put("Authorization", "Bearer " + oAuthTokenGenerator.getAccessToken());
         return requestHeaders;

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <hystrix.version>1.4.0-RC5</hystrix.version>
         <jackson.version>2.5.2</jackson.version>
         <jetty.version>9.2.10.v20150310</jetty.version>
-        <phantom.version>2.0.1</phantom.version>
+        <phantom.version>3.0.0-SNAPSHOT</phantom.version>
         <brave.version>2.2.1</brave.version>
         <slf4j.api.version>1.7.9</slf4j.api.version>
         <log4j.version>2.6.2</log4j.version>

--- a/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/AbstractServiceClient.java
+++ b/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/AbstractServiceClient.java
@@ -38,6 +38,10 @@ import java.util.Map;
 import java.util.concurrent.Future;
 
 import static com.flipkart.poseidon.serviceclients.ServiceClientConstants.HEADERS;
+import static com.flipkart.poseidon.handlers.http.HandlerConstants.HTTP_HEADERS;
+import static com.flipkart.poseidon.handlers.http.HandlerConstants.HTTP_METHOD;
+import static com.flipkart.poseidon.handlers.http.HandlerConstants.HTTP_URI;
+import static com.flipkart.poseidon.handlers.http.HandlerConstants.X_CACHE_REQUEST;
 
 /**
  * Created by mohan.pandian on 24/02/15.
@@ -85,17 +89,17 @@ public abstract class AbstractServiceClient implements ServiceClient {
         }
         logger.info("Executing {} with {} {}", commandName, httpMethod, uri);
 
-        Map<String, String> params = new HashMap<>();
-        params.put("uri", uri);
-        params.put("method", httpMethod);
+        Map<String, Object> params = new HashMap<>();
+        params.put(HTTP_URI, uri);
+        params.put(HTTP_METHOD, httpMethod);
         if (requestCachingEnabled) {
-            params.put("X-Cache-Request", "true");
+            params.put(X_CACHE_REQUEST, "true");
         }
 
         Map<String, String> injectedHeadersMap = injectHeaders(headersMap);
         if (!injectedHeadersMap.isEmpty()) {
             try {
-                params.put("headers", getObjectMapper().writeValueAsString(injectedHeadersMap));
+                params.put(HTTP_HEADERS, injectedHeadersMap);
             } catch (Exception e) {
                 logger.error("Error serializing headers", e);
                 throw new IOException("Headers serialization error", e);


### PR DESCRIPTION
Between service clients and task handler, http headers map get serialized to string and then get de-serialized back to map and sent over wire. This will be a backward compatible change, hence not planning to do this in 4.x (especially for other service clients and task handlers written by hand).

To be merged after phantom PR gets merged and released.
https://github.com/Flipkart/phantom/pull/61

Essence of changes:
1. Certain strings used between service-clients-core and http-handler are moved to Constants.
2. Params given to Task Handler is no more a Map < String, String >. It is a Map < String, Object >. Hence headers map can be passed as value. So no need to use object mapper in service client to serialize this and no need to use object mapper in task handler to de-serialize this
3. Upgrade to phantom 3.0.0-SNAPSHOT (yet to be released) which has this contract change for task handlers, task context etc.