### PR TITLE
Treat 5xx errors from http upstreams as hystrix command failures

### DIFF
--- a/container/src/main/java/com/flipkart/poseidon/filters/HystrixContextFilter.java
+++ b/container/src/main/java/com/flipkart/poseidon/filters/HystrixContextFilter.java
@@ -122,8 +122,9 @@ public class HystrixContextFilter implements Filter {
         HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().stream().filter(
                 command -> command.isResponseTimedOut() || command.isFailedExecution() || command.isResponseShortCircuited() || command.isResponseRejected()
         ).forEach(
-                command -> logger.error("URL: {}. Global headers: {}. Command: {}. Events: {}. Exception: ",
-                        url, globalHeaders, command.getCommandKey().name(), command.getExecutionEvents(), command.getFailedExecutionException())
+                command -> logger.error("URL: {}. Global headers: {}. Command: {}. Events: {}. Exception: {}",
+                        url, globalHeaders, command.getCommandKey().name(), command.getExecutionEvents(),
+                        command.getFailedExecutionException() == null ? "" : command.getFailedExecutionException().getMessage())
         );
     }
 }

--- a/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/SinglePoolHttpTaskHandler.java
+++ b/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/SinglePoolHttpTaskHandler.java
@@ -200,7 +200,25 @@ public class SinglePoolHttpTaskHandler extends RequestCacheableHystrixTaskHandle
     /** interface method implementation */
     @Override
     public <T, S> TaskResult<T> getFallBack(TaskContext taskContext, String command, Map<String, Object> params, S data) {
-        return null;
+        throw new UnsupportedOperationException("No fallback available.");
+    }
+
+    /**
+     * No fallback for execution failures. Throw an exception here so that hystrix propagates it up to the caller.
+     * If we just return null, hystrix will mark fallback success and return null result to caller but we want failure in execute() to bubble up.
+     *
+     * @param taskContext
+     * @param command
+     * @param taskRequestWrapper
+     * @param decoder
+     * @param <T>
+     * @param <S>
+     * @return
+     * @throws RuntimeException
+     */
+    @Override
+    public <T, S> TaskResult<T> getFallBack(TaskContext taskContext, String command, TaskRequestWrapper<S> taskRequestWrapper, Decoder<T> decoder) throws RuntimeException {
+        throw new UnsupportedOperationException("No fallback available.");
     }
 
     /** interface method implementation */

--- a/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/ServiceResponseDecoder.java
+++ b/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/ServiceResponseDecoder.java
@@ -93,28 +93,32 @@ public class ServiceResponseDecoder<T> implements HttpResponseDecoder<ServiceRes
                 }
             }
         } else {
-            try {
-                String serviceResponse = StringUtils.convertStreamToString(httpResponse.getEntity().getContent());
-                Object errorResponse = null;
+            String serviceResponse = StringUtils.convertStreamToString(httpResponse.getEntity().getContent());
+            Object errorResponse = null;
+            if (errorType != null) {
                 try {
-                    if (errorType != null) {
-                        errorResponse = objectMapper.readValue(serviceResponse, errorType);
-                    }
+                    errorResponse = objectMapper.readValue(serviceResponse, errorType);
                 } catch (Exception e) {
                     logger.warn("Error while de-serializing non 200 response to given errorType statusCode:{} exception: {}", statusCodeString, e.getMessage());
                 }
-                logger.warn("Non 200 response statusCode:{} response: {}", statusCodeString, serviceResponse);
-                Class<? extends ServiceClientException> exceptionClass;
-                if (exceptions.containsKey(statusCodeString))
-                    exceptionClass = exceptions.get(statusCodeString);
-                else
-                    exceptionClass = exceptions.get("default");
+            }
+            Class<? extends ServiceClientException> exceptionClass;
+            if (exceptions.containsKey(statusCodeString)) {
+                exceptionClass = exceptions.get(statusCodeString);
+            } else {
+                exceptionClass = exceptions.get("default");
+            }
 
-                return new ServiceResponse<T>(exceptionClass.getConstructor(String.class, Object.class).newInstance(serviceResponse, errorResponse), headers);
-
-            } catch (Exception e) {
-                logger.error("Error de-serializing non 200 response statusCode:{} exception: {} ", statusCodeString, e.getMessage());
-                throw new IOException("Non 200 response de-serialization error", e);
+            String exceptionMessage = statusCodeString + " " + serviceResponse;
+            ServiceClientException serviceClientException = exceptionClass.getConstructor(String.class, Object.class).newInstance(exceptionMessage, errorResponse);
+            if (statusCode >= 500 && statusCode <= 599) {
+                // 5xx errors have to be treated as hystrix command failures. Hence throw service client exception.
+                logger.error("Non 200 response statusCode: {} response: {}", statusCodeString, serviceResponse);
+                throw serviceClientException;
+            } else {
+                // Rest of non 2xx don't have to be treated as hystrix command failures (ex: validation failure resulting in 400)
+                logger.debug("Non 200 response statusCode: {} response: {}", statusCodeString, serviceResponse);
+                return new ServiceResponse<T>(serviceClientException, headers);
             }
         }
     }

--- a/service-clients-core/src/test/java/com/flipkart/poseidon/serviceclients/ServiceResponseDecoderTest.java
+++ b/service-clients-core/src/test/java/com/flipkart/poseidon/serviceclients/ServiceResponseDecoderTest.java
@@ -44,9 +44,7 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.powermock.api.mockito.PowerMockito.*;
@@ -152,7 +150,7 @@ public class ServiceResponseDecoderTest {
         ServiceResponse response = decoder.decode(mockHttpResponse);
         assertThat(response.getException(), instanceOf(ServiceClientException.class));
         assertThat(response.getException().getErrorResponse(), instanceOf(mockErrorType.getRawClass()));
-        Mockito.verify(mockLogger).warn("Non 200 response statusCode:{} response: {}", "404", errorString);
+        Mockito.verify(mockLogger).debug("Non 200 response statusCode: {} response: {}", "404", errorString);
     }
 
     /**
@@ -182,7 +180,7 @@ public class ServiceResponseDecoderTest {
         ServiceResponse response = decoder.decode(mockHttpResponse);
         assertThat(response.getException(), instanceOf(ServiceClientException.class));
         assertEquals(response.getException().getErrorResponse(), null);
-        Mockito.verify(mockLogger).warn("Non 200 response statusCode:{} response: {}", "404", errorString);
+        Mockito.verify(mockLogger).debug("Non 200 response statusCode: {} response: {}", "404", errorString);
     }
 
     /**
@@ -212,8 +210,8 @@ public class ServiceResponseDecoderTest {
         ServiceResponse response = decoder.decode(mockHttpResponse);
         assertThat(response.getException(), instanceOf(ServiceClientException.class));
         assertEquals(response.getException().getErrorResponse(), null);
-        Mockito.verify(mockLogger).warn("Non 200 response statusCode:{} response: {}", "404", errorString);
-        Mockito.verify(mockLogger, Mockito.times(2)).warn(anyString(), anyString(), any(Object.class));
+        Mockito.verify(mockLogger).debug("Non 200 response statusCode: {} response: {}", "404", errorString);
+        Mockito.verify(mockLogger).warn(anyString(), anyString(), any(Object.class));
     }
 
     /**
@@ -235,35 +233,13 @@ public class ServiceResponseDecoderTest {
         when(StringUtils.convertStreamToString(stream)).thenReturn("error");
         exceptions.put("default", ServiceClientException.class);
 
-        ServiceResponse response = decoder.decode(mockHttpResponse);
-        assertThat(response.getException(), instanceOf(ServiceClientException.class));
-        Mockito.verify(mockLogger).warn("Non 200 response statusCode:{} response: {}","500", "error");
-
-    }
-
-    /**
-     *  Service returned un known status line(not in expected statusLines) and decode fails
-     * @throws Exception
-     */
-    @Test
-    public void testDecodeHttpResponseDefaultResponseDecodeFail() throws Exception {
-        HttpResponse mockHttpResponse = mock(HttpResponse.class);
-        StatusLine mockStatusLine = mock(StatusLine.class);
-        HttpEntity mockEntity = mock(HttpEntity.class);
-        InputStream stream = mock(InputStream.class);
-
-        when(mockStatusLine.getStatusCode()).thenReturn(500);
-        when(mockHttpResponse.getStatusLine()).thenReturn(mockStatusLine);
-        when(mockHttpResponse.getEntity()).thenReturn(mockEntity);
-        when(mockEntity.getContent()).thenReturn(stream);
-        mockStatic(StringUtils.class);
-        when(StringUtils.convertStreamToString(stream)).thenThrow(IOException.class);
-        exceptions.put("default", ServiceClientException.class);
-
-        exception.expect(IOException.class);
-        exception.expectMessage(equalTo("Non 200 response de-serialization error"));
-        ServiceResponse response = decoder.decode(mockHttpResponse);
-        Mockito.verify(mockLogger).error("Error de-serializing non 200 response");
+        try {
+            ServiceResponse response = decoder.decode(mockHttpResponse);
+            fail("Decoder should throw exception for 5xx status, but didn't!");
+        } catch(Exception e) {
+            assertThat(e, instanceOf(ServiceClientException.class));
+        }
+        Mockito.verify(mockLogger).error("Non 200 response statusCode: {} response: {}","500", "error");
 
     }
 


### PR DESCRIPTION
When an upstream throws 5xx error, poseidon doesn't convert it into a hystrix command failure. Any 5xx response from any upstream should be treated as hystrix command failure and repeated 5xx should trigger circuit breaker logic. Hence, its not required to customize this behaviour per service client.

Implication:
A service having two endpoints might throw 5xx for one endpoint but not for other endpoint. Hence if both are wrapped in same hystrix command, repeated failures in one API endpoint might result in open circuit for both end points. This will be captured in migration guide.

Approach:
Layers involved (between poseidon, phantom and hystrix) are:
DataSource thread:
DataSource -> FutureTaskResultToObjectPromiseWrapper

Hystrix thread:
TaskHandlerExecutor -> SinglePoolHttpTaskHandler -> ServiceResponseDecoder.

Existing behaviour:
Currently ServiceResponseDecoder just logs failures and returns a valid task result with exception inside it. FutureTaskResultToObjectPromiseWrapper throws this ServiceClientException in DataSource thread which is then caught by DataSource's try/catch as service failure.

New behaviour:
ServiceResponseDecoder will throw ServiceClientException only for 5xx error response (in addition to existing logging) so that HystrixCommand execute() fails. SinglePoolHttpTaskHandler will throw exception in its fallback so that hystrix propagates failure in execute() to caller. Otherwise hystrix will just return the fallback result back to caller with no exception. Now FutureTaskResultToObjectPromiseWrapper will catch ExecutionException with root cause as ServiceClientException and throw it back to DataSource.

PS:
1. This will be a backward compatible change. Hence a DataSource waiting on service client future, will still get the same ServiceClientException.
2. This can be achieved using changes in Poseidon alone without touching phantom/hystrix.