### PR TITLE
Started ingesting status code based jmx metrics

### DIFF
--- a/container/pom.xml
+++ b/container/pom.xml
@@ -33,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-fileupload</groupId>

--- a/container/src/main/java/com/flipkart/poseidon/filters/RequestGzipFilter.java
+++ b/container/src/main/java/com/flipkart/poseidon/filters/RequestGzipFilter.java
@@ -81,6 +81,21 @@ public class RequestGzipFilter implements Filter {
             final ByteArrayInputStream sourceStream = new ByteArrayInputStream(bytes);
             return new ServletInputStream() {
 
+                @Override
+                public boolean isFinished() {
+                    return false;
+                }
+
+                @Override
+                public boolean isReady() {
+                    return true;
+                }
+
+                @Override
+                public void setReadListener(ReadListener readListener) {
+
+                }
+
                 public int read() throws IOException {
                     return sourceStream.read();
                 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,7 +28,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.netflix.hystrix</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -98,9 +98,8 @@
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>
-                <artifactId>servlet-api</artifactId>
-                <version>2.5</version>
-                <scope>provided</scope>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>3.1.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
## Changes to ingest status code metrics for all Http Requests
- [x] Bump up servlet-api version and make associated changes.
- [x] Start sending only count information for status codes (rates could be derivable)
- [x] Send out 2xx, 3xx, 4xx, 5xx for a start (support for specific status codes could be added separately.
