### PR TITLE
Using phantom 3.4.0 which passes execution failures to fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 5.1.0 (WIP) (Feb 21, 2017)
+## 5.1.0 (WIP) (Feb 28, 2017)
 - Upgrade Jetty version to v9.4.1.v20170120
 - Support incoming PATCH method calls
 - Support PATCH calls for service clients
-- Bumping Phantom to 3.3.0
+- Bumping Phantom to 3.4.0
 
 ## 5.0.0 (Jan 2, 2017)
 - Included snapshot version fixes

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <hystrix.metrics.plugin.version>1.4.0-RC5</hystrix.metrics.plugin.version>
         <jackson.version>2.5.2</jackson.version>
         <jetty.version>9.4.1.v20170120</jetty.version>
-        <phantom.version>3.3.0</phantom.version>
+        <phantom.version>3.4.0-SNAPSHOT</phantom.version>
         <brave.version>2.2.1</brave.version>
         <slf4j.api.version>1.7.9</slf4j.api.version>
         <log4j.version>2.6.2</log4j.version>


### PR DESCRIPTION
For this phantom fix - https://github.com/Flipkart/phantom/pull/68