### PR TITLE
Added method to the name for status code based API metrics. ( MOBENG-21096 )

### DIFF
--- a/api/src/main/java/com/flipkart/poseidon/api/APILegoSet.java
+++ b/api/src/main/java/com/flipkart/poseidon/api/APILegoSet.java
@@ -21,6 +21,7 @@ import com.flipkart.poseidon.core.PoseidonRequest;
 import com.flipkart.poseidon.core.RequestContext;
 import com.flipkart.poseidon.ds.trie.KeyWrapper;
 import com.flipkart.poseidon.ds.trie.Trie;
+import com.flipkart.poseidon.helpers.MetricsHelper;
 import com.flipkart.poseidon.legoset.PoseidonLegoSet;
 import com.flipkart.poseidon.metrics.Metrics;
 import com.flipkart.poseidon.pojos.EndpointPOJO;
@@ -106,7 +107,7 @@ public abstract class APILegoSet extends PoseidonLegoSet {
 
             String name = pojo.getName();
             if (name != null && !name.isEmpty()) {
-                poseidonRequest.setAttribute(TIMER_CONTEXT, Metrics.getRegistry().timer("poseidon.api." + name + "." + httpMethod).time());
+                poseidonRequest.setAttribute(TIMER_CONTEXT, Metrics.getRegistry().timer(MetricsHelper.getApiTimerMetricsName(name, httpMethod)).time());
             }
         }
 

--- a/container/src/main/java/com/flipkart/poseidon/filters/HystrixContextFilter.java
+++ b/container/src/main/java/com/flipkart/poseidon/filters/HystrixContextFilter.java
@@ -127,11 +127,11 @@ public class HystrixContextFilter implements Filter {
      * A command might not have been executed (say threadpool/semaphore rejected,
      * short circuited). Command might have been executed but failed (say timed out,
      * command execution failed).
-     * <p>
+     *
      * This is required as Phantom's RequestLogger logs failures of sync command
      * executions alone (and not async command executions) and doesn't provide request
      * level view of all commands.
-     * <p>
+     *
      * We log global headers here as it typically contains request id
      */
     private void logFailedHystrixCommands(ServletRequest request) {

--- a/container/src/main/java/com/flipkart/poseidon/filters/HystrixContextFilter.java
+++ b/container/src/main/java/com/flipkart/poseidon/filters/HystrixContextFilter.java
@@ -18,6 +18,7 @@ package com.flipkart.poseidon.filters;
 
 import com.flipkart.poseidon.api.Configuration;
 import com.flipkart.poseidon.api.HeaderConfiguration;
+import com.flipkart.poseidon.constants.RequestConstants;
 import com.flipkart.poseidon.core.RequestContext;
 import com.flipkart.poseidon.handlers.http.utils.StringUtils;
 import com.flipkart.poseidon.metrics.Metrics;
@@ -70,7 +71,9 @@ public class HystrixContextFilter implements Filter {
         // Ingest API response status codes for HttpServletResponse
         if (response instanceof HttpServletResponse && !StringUtils.isNullOrEmpty(RequestContext.get(ENDPOINT_NAME))) {
             String status = (((HttpServletResponse) response).getStatus() / 100) + "XX";
-            Metrics.getRegistry().counter("poseidon.api." + RequestContext.get(ENDPOINT_NAME) + "." + status).inc();
+            Metrics.getRegistry()
+                    .counter("poseidon.api." + RequestContext.get(ENDPOINT_NAME) + "_" + RequestContext.get(RequestConstants.METHOD) + "." + status)
+                    .inc();
         }
     }
 

--- a/container/src/main/java/com/flipkart/poseidon/filters/HystrixContextFilter.java
+++ b/container/src/main/java/com/flipkart/poseidon/filters/HystrixContextFilter.java
@@ -21,6 +21,7 @@ import com.flipkart.poseidon.api.HeaderConfiguration;
 import com.flipkart.poseidon.constants.RequestConstants;
 import com.flipkart.poseidon.core.RequestContext;
 import com.flipkart.poseidon.handlers.http.utils.StringUtils;
+import com.flipkart.poseidon.helpers.MetricsHelper;
 import com.flipkart.poseidon.metrics.Metrics;
 import com.flipkart.poseidon.serviceclients.ServiceClientConstants;
 import com.flipkart.poseidon.serviceclients.ServiceContext;
@@ -72,7 +73,7 @@ public class HystrixContextFilter implements Filter {
         if (response instanceof HttpServletResponse && !StringUtils.isNullOrEmpty(RequestContext.get(ENDPOINT_NAME))) {
             String status = (((HttpServletResponse) response).getStatus() / 100) + "XX";
             Metrics.getRegistry()
-                    .counter("poseidon.api." + RequestContext.get(ENDPOINT_NAME) + "_" + RequestContext.get(RequestConstants.METHOD) + "." + status)
+                    .counter(MetricsHelper.getStatusCodeMetricsName(RequestContext.get(ENDPOINT_NAME), RequestContext.get(RequestConstants.METHOD), status))
                     .inc();
         }
     }
@@ -126,11 +127,11 @@ public class HystrixContextFilter implements Filter {
      * A command might not have been executed (say threadpool/semaphore rejected,
      * short circuited). Command might have been executed but failed (say timed out,
      * command execution failed).
-     *
+     * <p>
      * This is required as Phantom's RequestLogger logs failures of sync command
      * executions alone (and not async command executions) and doesn't provide request
      * level view of all commands.
-     *
+     * <p>
      * We log global headers here as it typically contains request id
      */
     private void logFailedHystrixCommands(ServletRequest request) {

--- a/container/src/main/java/com/flipkart/poseidon/helpers/MetricsHelper.java
+++ b/container/src/main/java/com/flipkart/poseidon/helpers/MetricsHelper.java
@@ -1,0 +1,28 @@
+package com.flipkart.poseidon.helpers;
+
+/**
+ * Created by shubham.srivastava on 19/04/17.
+ */
+public class MetricsHelper {
+
+    private static String BASE_METRICS_NAME = "poseidon.api.";
+    private static String DEFAULT_DELIMITER = ".";
+
+    public static String getStatusCodeMetricsName(String endpoint, String method, String status) {
+        return new StringBuilder(BASE_METRICS_NAME)
+                .append(endpoint)
+                .append(method)
+                .append(DEFAULT_DELIMITER)
+                .append(status)
+                .toString();
+    }
+
+    public static String getApiTimerMetricsName(String endpoint, String method) {
+        return new StringBuilder(BASE_METRICS_NAME)
+                .append(endpoint)
+                .append(DEFAULT_DELIMITER)
+                .append(method)
+                .toString();
+    }
+
+}

--- a/container/src/main/java/com/flipkart/poseidon/helpers/MetricsHelper.java
+++ b/container/src/main/java/com/flipkart/poseidon/helpers/MetricsHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Flipkart Internet, pvt ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.flipkart.poseidon.helpers;
 
 /**

--- a/container/src/main/java/com/flipkart/poseidon/helpers/MetricsHelper.java
+++ b/container/src/main/java/com/flipkart/poseidon/helpers/MetricsHelper.java
@@ -27,6 +27,7 @@ public class MetricsHelper {
     public static String getStatusCodeMetricsName(String endpoint, String method, String status) {
         return new StringBuilder(BASE_METRICS_NAME)
                 .append(endpoint)
+                .append(DEFAULT_DELIMITER)
                 .append(method)
                 .append(DEFAULT_DELIMITER)
                 .append(status)


### PR DESCRIPTION
Existing metrics that get pushed are of the form - ```poseidon.api.<name>.2XX```
Since there can be multiple APIs with the same name, it is important to include the method in the metric name.

The updated metrics would be - ```poseidon.api.<name>_<method>.2XX```