### PR TITLE
Bug fix in passing context to loop over DS and bumped version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.7.0 (WIP)
+- Loop over DataSource bug fixes and sample
+
 ## 5.6.0 (June 28, 2018)
 - Support for multiple error types in ServiceResponseDecoder 
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ Poseidon is a platform to build API applications that have to aggregate data fro
 
 | Release | Date | Description |
 |:------------|:----------------|:------------|
+| Version 5.6.0             | Jun 28 2018      |    Multiple error types in ServiceResponseDecoder
 | Version 5.5.0             | May 23 2018      |    Added follow redirect option in SinglePoolHttpTaskHandler
 | Version 5.4.1             | Nov 05 2017      |    Bugfix to stop stacktrace leak
 | Version 5.4.0             | Oct 13 2017      |    Support for DataTypes in headers, path params and support for enums and generics in API definitions
-| Version 5.3.0             | Jun 27 2017      |    Ability to define and consume additional fields for an endpoint to be used as meta information
-| Version 5.2.0             | Jun 07 2017      |    Debug flag in APIs to list all service responses, collect response headers from all services
 
 ## Changelog
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.6.0</version>
+        <version>5.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>api</artifactId>

--- a/api/src/main/java/com/flipkart/poseidon/internal/APITask.java
+++ b/api/src/main/java/com/flipkart/poseidon/internal/APITask.java
@@ -51,7 +51,7 @@ public class APITask extends DefaultMultiTask {
             return getDataSource(values);
         } else {
             try {
-                return new DataSourceCallable(legoSet, executor, name, loopComposer, composer, values);
+                return new ContextInducedCallable(new DataSourceCallable(legoSet, executor, name, loopComposer, composer, values));
             } catch (NoSuchMethodException | ComposerEvaluationException e) {
                 throw new BadCallableException("Unable to execute callable", e);
             }

--- a/api/src/main/java/com/flipkart/poseidon/internal/CallableBlock.java
+++ b/api/src/main/java/com/flipkart/poseidon/internal/CallableBlock.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 Flipkart Internet, pvt ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.flipkart.poseidon.internal;
+
+import flipkart.lego.api.entities.Block;
+
+import java.util.concurrent.Callable;
+
+public interface CallableBlock<T> extends Callable<T>, Block {
+}

--- a/api/src/main/java/com/flipkart/poseidon/internal/ContextInducedCallable.java
+++ b/api/src/main/java/com/flipkart/poseidon/internal/ContextInducedCallable.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Flipkart Internet, pvt ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.flipkart.poseidon.internal;
+
+import com.flipkart.poseidon.legoset.ContextInducedBlock;
+
+import java.util.concurrent.Callable;
+
+public class ContextInducedCallable extends ContextInducedBlock implements Callable {
+    private final CallableBlock callableBlock;
+
+    ContextInducedCallable(CallableBlock callableBlock) {
+        super(callableBlock);
+        this.callableBlock = callableBlock;
+    }
+
+    @Override
+    public Object call() throws Exception {
+        try {
+            initAllContext(null);
+            Object result = callableBlock.call();
+            success = true;
+            return result;
+        } finally {
+            shutdownAllContext();
+        }
+    }
+}

--- a/api/src/main/java/com/flipkart/poseidon/internal/DataSourceCallable.java
+++ b/api/src/main/java/com/flipkart/poseidon/internal/DataSourceCallable.java
@@ -22,6 +22,7 @@ import com.flipkart.hydra.task.entities.WrapperCallable;
 import com.flipkart.hydra.task.exception.BadCallableException;
 import com.flipkart.poseidon.datasources.DataSourceRequest;
 import com.flipkart.poseidon.legoset.PoseidonLegoSet;
+import com.flipkart.poseidon.model.annotations.Trace;
 import com.google.common.util.concurrent.ListenableFuture;
 import flipkart.lego.api.entities.DataSource;
 import flipkart.lego.api.exceptions.ElementNotFoundException;
@@ -34,7 +35,8 @@ import java.util.concurrent.ExecutorService;
 
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 
-public class DataSourceCallable extends WrapperCallable {
+@Trace(false)
+public class DataSourceCallable extends WrapperCallable implements CallableBlock<Object> {
 
     private final PoseidonLegoSet legoSet;
     private final String dataSourceName;

--- a/cadfael-maven-plugin/pom.xml
+++ b/cadfael-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.6.0</version>
+        <version>5.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cadfael-maven-plugin</artifactId>

--- a/cadfael/pom.xml
+++ b/cadfael/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.6.0</version>
+        <version>5.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cadfael</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.6.0</version>
+        <version>5.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.6.0</version>
+        <version>5.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>container</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.6.0</version>
+        <version>5.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/http-handler/pom.xml
+++ b/http-handler/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.flipkart.poseidon</groupId>
 		<artifactId>poseidon</artifactId>
-		<version>5.6.0</version>
+		<version>5.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>http-handler</artifactId>

--- a/log4j-access/pom.xml
+++ b/log4j-access/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.6.0</version>
+        <version>5.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>log4j-access</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.flipkart.poseidon</groupId>
     <artifactId>poseidon</artifactId>
-    <version>5.6.0</version>
+    <version>5.7.0-SNAPSHOT</version>
 
     <name>Poseidon</name>
     <description>A platform to build API applications that have to aggregate data from distributed services in an efficient way</description>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>poseidon</artifactId>
         <groupId>com.flipkart.poseidon</groupId>
-        <version>5.6.0</version>
+        <version>5.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample</artifactId>

--- a/sample/src/main/java/com/flipkart/poseidon/sample/datasources/CommentsDataSource.java
+++ b/sample/src/main/java/com/flipkart/poseidon/sample/datasources/CommentsDataSource.java
@@ -47,7 +47,7 @@ public class CommentsDataSource extends AbstractDataSource<PostWithCommentsDataT
         try {
             int index = request.getAttribute("index");
             PostDataType post = request.getAttribute("post");
-            logger.info("Index: {}, PostDataType: {}", index, post);
+            logger.info("Index: {}, Post Id: {}", index, post.getPostId());
 
             // Fetch comments through service client
             SampleServiceClient serviceClient = (SampleServiceClient) legoset.getServiceClient("sampleSC_1.0.0");

--- a/sampleSC/pom.xml
+++ b/sampleSC/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>poseidon</artifactId>
         <groupId>com.flipkart.poseidon</groupId>
-        <version>5.6.0</version>
+        <version>5.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sampleSC</artifactId>

--- a/service-clients-archetype/pom.xml
+++ b/service-clients-archetype/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.6.0</version>
+        <version>5.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-clients-archetype</artifactId>

--- a/service-clients-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/service-clients-archetype/src/main/resources/archetype-resources/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.flipkart.poseidon</groupId>
             <artifactId>service-clients-core</artifactId>
-            <version>5.6.0</version>
+            <version>5.7.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
@@ -51,12 +51,12 @@
                     <dependency>
                         <groupId>com.flipkart.poseidon</groupId>
                         <artifactId>service-clients-core</artifactId>
-                        <version>5.6.0</version>
+                        <version>5.7.0-SNAPSHOT</version>
                     </dependency>
                     <dependency>
                         <groupId>com.flipkart.poseidon</groupId>
                         <artifactId>service-clients-gen</artifactId>
-                        <version>5.6.0</version>
+                        <version>5.7.0-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/service-clients-core/pom.xml
+++ b/service-clients-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.6.0</version>
+        <version>5.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-clients-core</artifactId>

--- a/service-clients-gen/pom.xml
+++ b/service-clients-gen/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.6.0</version>
+        <version>5.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-clients-gen</artifactId>


### PR DESCRIPTION
Loop over DataSource (CommentsDataSource in sample) wasn't getting context from parent thread as it was executed from a Callable (DataSourceCallable) that extends WrapperCallable of Hydra.

Provided a ContextInducedCallable similar to ContextInducedDataSource, ContextInducedFilter and made this work. Tested with [whatIsWrongWithThis](http://localhost:21000/v1/userPosts?userId=1&whatIsWrongWithThis) API on sample to get "comments" service responses (which wasn't coming before the bug fix).

Updated changelog, releases and bumped up version to 5.7.0-SNAPSHOT (changes are backward compatible and working feature of loop over datasource)