### PR TITLE
Supporting LONG in API parameter

### DIFF
--- a/api/src/main/java/com/flipkart/poseidon/internal/ParamValidationFilter.java
+++ b/api/src/main/java/com/flipkart/poseidon/internal/ParamValidationFilter.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -244,6 +245,8 @@ public class ParamValidationFilter implements Filter {
                 return getDoubleValues(values);
             case INTEGER:
                 return getIntegerValues(values);
+            case LONG:
+                return getLongValues(values);
             case BOOLEAN:
                 return getBooleanValues(values);
             case ENUM:
@@ -269,6 +272,10 @@ public class ParamValidationFilter implements Filter {
         }
 
         return integerValues;
+    }
+
+    private List<Long> getLongValues(String[] values) {
+        return Arrays.stream(values).map(Long::parseLong).collect(Collectors.toList());
     }
 
     private List<Boolean> getBooleanValues(String[] values) {

--- a/api/src/main/java/com/flipkart/poseidon/pojos/ParamPOJO.java
+++ b/api/src/main/java/com/flipkart/poseidon/pojos/ParamPOJO.java
@@ -117,7 +117,7 @@ public class ParamPOJO {
     }
 
     public static enum DataType {
-        STRING, INTEGER, NUMBER, BOOLEAN, ENUM;
+        STRING, INTEGER, LONG, NUMBER, BOOLEAN, ENUM;
 
         @JsonCreator
         public static DataType getValueFor(String value) {

--- a/api/src/test/java/com/flipkart/poseidon/internal/ParamValidationFilterTest.java
+++ b/api/src/test/java/com/flipkart/poseidon/internal/ParamValidationFilterTest.java
@@ -271,8 +271,9 @@ public class ParamValidationFilterTest {
         ParamPOJO paramPOJO2 = mockQueryParam("test2", ParamPOJO.DataType.BOOLEAN);
         ParamPOJO paramPOJO3 = mockQueryParam("test3", ParamPOJO.DataType.INTEGER);
         ParamPOJO paramPOJO4 = mockQueryParam("test4", ParamPOJO.DataType.NUMBER);
+        ParamPOJO paramPOJO5 = mockQueryParam("test5", ParamPOJO.DataType.LONG);
 
-        ParamPOJO[] paramPOJOs = new ParamPOJO[] { paramPOJO, paramPOJO2, paramPOJO3, paramPOJO4 };
+        ParamPOJO[] paramPOJOs = new ParamPOJO[] { paramPOJO, paramPOJO2, paramPOJO3, paramPOJO4, paramPOJO5 };
         when(params.getRequired()).thenReturn(paramPOJOs);
 
         Map<String, String[]> parameterMap = new HashMap<>();
@@ -280,6 +281,7 @@ public class ParamValidationFilterTest {
         parameterMap.put("test2", new String[] { "true" });
         parameterMap.put("test3", new String[] { "2132" });
         parameterMap.put("test4", new String[] { "32.532" });
+        parameterMap.put("test5", new String[] { "2147483648" });
 
         RequestContext.set(RequestConstants.URI, "/3/abc/xyz");
         HttpServletRequest servletRequest = mockHttpServletRequest("/3/abc/xyz", parameterMap);
@@ -288,7 +290,7 @@ public class ParamValidationFilterTest {
         new ParamValidationFilter(params, configuration).filterRequest(request, new PoseidonResponse());
 
         Map<String, Object> parsedParams = request.getAttribute(RequestConstants.PARAMS);
-        assertEquals(4, parsedParams.size());
+        assertEquals(5, parsedParams.size());
 
         Object test = parsedParams.get("test");
         assertTrue(test instanceof String);
@@ -305,6 +307,10 @@ public class ParamValidationFilterTest {
         Object test4 = parsedParams.get("test4");
         assertTrue(test4 instanceof Double);
         assertEquals(32.532, test4);
+
+        Object test5 = parsedParams.get("test5");
+        assertTrue(test5 instanceof Long);
+        assertEquals(2147483648L, test5);
     }
 
     @Test
@@ -315,8 +321,9 @@ public class ParamValidationFilterTest {
         ParamPOJO paramPOJO2 = mockHeaderParam("test2", ParamPOJO.DataType.BOOLEAN);
         ParamPOJO paramPOJO3 = mockHeaderParam("test3", ParamPOJO.DataType.INTEGER);
         ParamPOJO paramPOJO4 = mockHeaderParam("test4", ParamPOJO.DataType.NUMBER);
+        ParamPOJO paramPOJO5 = mockHeaderParam("test5", ParamPOJO.DataType.LONG);
 
-        ParamPOJO[] paramPOJOs = new ParamPOJO[] { paramPOJO, paramPOJO2, paramPOJO3, paramPOJO4 };
+        ParamPOJO[] paramPOJOs = new ParamPOJO[] { paramPOJO, paramPOJO2, paramPOJO3, paramPOJO4, paramPOJO5 };
         when(params.getRequired()).thenReturn(paramPOJOs);
 
         Map<String, String> headers = new HashMap<>();
@@ -324,6 +331,7 @@ public class ParamValidationFilterTest {
         headers.put("test2", "true");
         headers.put("test3", "2132");
         headers.put("test4", "32.532");
+        headers.put("test5", "2147483648");
 
         RequestContext.set(RequestConstants.URI, "/3/abc/xyz");
         HttpServletRequest servletRequest = mockHttpServletRequest("/3/abc/xyz", new HashMap<>(), headers);
@@ -332,7 +340,7 @@ public class ParamValidationFilterTest {
         new ParamValidationFilter(params, configuration).filterRequest(request, new PoseidonResponse());
 
         Map<String, Object> parsedParams = request.getAttribute(RequestConstants.PARAMS);
-        assertEquals(4, parsedParams.size());
+        assertEquals(5, parsedParams.size());
 
         Object test = parsedParams.get("test");
         assertTrue(test instanceof String);
@@ -349,6 +357,10 @@ public class ParamValidationFilterTest {
         Object test4 = parsedParams.get("test4");
         assertTrue(test4 instanceof Double);
         assertEquals(32.532, test4);
+
+        Object test5 = parsedParams.get("test5");
+        assertTrue(test5 instanceof Long);
+        assertEquals(2147483648L, test5);
     }
 
     @Test
@@ -359,18 +371,19 @@ public class ParamValidationFilterTest {
         ParamPOJO paramPOJO2 = mockPathParam("test2", 4, ParamPOJO.DataType.BOOLEAN);
         ParamPOJO paramPOJO3 = mockPathParam("test3", 5, ParamPOJO.DataType.INTEGER);
         ParamPOJO paramPOJO4 = mockPathParam("test4", 6, ParamPOJO.DataType.NUMBER);
+        ParamPOJO paramPOJO5 = mockPathParam("test5", 7, ParamPOJO.DataType.LONG);
 
-        ParamPOJO[] paramPOJOs = new ParamPOJO[] { paramPOJO, paramPOJO2, paramPOJO3, paramPOJO4 };
+        ParamPOJO[] paramPOJOs = new ParamPOJO[] { paramPOJO, paramPOJO2, paramPOJO3, paramPOJO4, paramPOJO5 };
         when(params.getRequired()).thenReturn(paramPOJOs);
 
-        RequestContext.set(RequestConstants.URI, "/3/abc/{test}/{test2}/{test3}/{test4}");
-        HttpServletRequest servletRequest = mockHttpServletRequest("/3/abc/works/true/2132/32.532");
+        RequestContext.set(RequestConstants.URI, "/3/abc/{test}/{test2}/{test3}/{test4}/{test5}");
+        HttpServletRequest servletRequest = mockHttpServletRequest("/3/abc/works/true/2132/32.532/2147483648");
 
         PoseidonRequest request = new PoseidonRequest(servletRequest);
         new ParamValidationFilter(params, configuration).filterRequest(request, new PoseidonResponse());
 
         Map<String, Object> parsedParams = request.getAttribute(RequestConstants.PARAMS);
-        assertEquals(4, parsedParams.size());
+        assertEquals(5, parsedParams.size());
 
         Object test = parsedParams.get("test");
         assertTrue(test instanceof String);
@@ -387,6 +400,10 @@ public class ParamValidationFilterTest {
         Object test4 = parsedParams.get("test4");
         assertTrue(test4 instanceof Double);
         assertEquals(32.532, test4);
+
+        Object test5 = parsedParams.get("test5");
+        assertTrue(test5 instanceof Long);
+        assertEquals(2147483648L, test5);
     }
 
     @Test


### PR DESCRIPTION
As there is a use case to take long in query param, adding support for LONG in API parameter. Currently, we support only STRING, BOOLEAN, INTEGER, NUMBER (for double), ENUM. We can add other java types (like short, float etc) on need basis. javatype/type works only on body.