### PR TITLE
Upgrading hibernate-validator to fix admin dashboard not working locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.7.0 (WIP)
 - Loop over DataSource bug fixes and sample
 - LONG support in API parameter
+- Upgrade hibernate-validator to 5.4.2.Final
 
 ## 5.6.0 (June 28, 2018)
 - Support for multiple error types in ServiceResponseDecoder 

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>4.2.0.Final</version>
+                <version>5.4.2.Final</version>
             </dependency>
             <!-- Spring -->
 


### PR DESCRIPTION
hibernate-validator [4.2.0.Final](https://mvnrepository.com/artifact/org.hibernate/hibernate-validator/4.2.0.Final) is compatible with validation-api 1.0.0.GA.

But in our [http-handler](https://github.com/flipkart-incubator/Poseidon/blob/master/http-handler/pom.xml), we are using validation-api 1.1.0.Final explicitly.

So for clients who are explicitly using upgraded hibernate-validator version or getting 1.0.0.GA validation-api through transitive dependencies, [admin dashboard](http://localhost:8989/admin/dashboard) was working fine. For all other clients, admin dashboard wasn't working (503 service unavilable error) and in logs, this error message used to appear in startup logs
`java.lang.AbstractMethodError: org.hibernate.validator.internal.engine.ConfigurationImpl.getDefaultParameterNameProvider()Ljavax/validation/ParameterNameProvider`

So instead of downgrading validation-api, upgrading hibernate-validator from 4.x to 5.x. We can upgrade to [6.x](https://mvnrepository.com/artifact/org.hibernate/hibernate-validator/6.0.12.Final) later as it seems to have more changes like no direct compile time dependency on validation-api etc.

Have tested OSS sample and no issues observed with this upgrade.