### PR TITLE
custom service client groupId while generating serviceclients

### DIFF
--- a/service-clients-gen/src/main/java/com/flipkart/poseidon/serviceclients/generator/Generator.java
+++ b/service-clients-gen/src/main/java/com/flipkart/poseidon/serviceclients/generator/Generator.java
@@ -44,6 +44,8 @@ public class Generator {
     private final static String DESTINATION_JAVA_FOLDER = ".target.generated-sources.";
     private final static JCodeModel jCodeModel = new JCodeModel();
     private final static Logger logger = LoggerFactory.getLogger(Generator.class);
+    private final static String SERVICE_CLIENT_GROUP_ID_KEY = "service.clients.groupId";
+    private final static String SERVICE_CLIENT_GROUP_ID_REGEX = "^([a-zA-Z_]+[.])*([a-zA-Z_]+)$";
 
     private static String moduleParentPath;
     private static String modulePath;
@@ -89,13 +91,13 @@ public class Generator {
         determineVersion(args[1]);
         String majorVersion = "v" + version.getMajor();
 
-        String serviceClientGroupId = System.getProperty("service.clients.groupId");
+        String serviceClientGroupId = System.getProperty(SERVICE_CLIENT_GROUP_ID_KEY);
         if (serviceClientGroupId == null || serviceClientGroupId.isEmpty()) {
             serviceClientGroupId = DEFAULT_SERVICE_CLIENT_GROUP_ID;
         }
 
         validateServiceClientGroupId(serviceClientGroupId);
-        packageName = trimmedPackageName(serviceClientGroupId) + "." + moduleName + "." + majorVersion;
+        packageName = serviceClientGroupId + "." + moduleName + "." + majorVersion;
 
         if (args.length > 2) {
             pojoOrdering = args[2].split(",");
@@ -104,14 +106,10 @@ public class Generator {
     }
 
     private static void validateServiceClientGroupId(String groupId) {
-        if (!groupId.matches("^([a-zA-Z_]+[.])*([a-zA-Z_]+)$")) {
+        if (!groupId.matches(SERVICE_CLIENT_GROUP_ID_REGEX)) {
             logger.error("Invalid value for property service.clients.groupId");
             System.exit(-1);
         }
-    }
-
-    private static String trimmedPackageName(String pkgName){
-        return pkgName.endsWith(".") ? pkgName.substring(0, pkgName.length() - 2) : pkgName;
     }
 
     private static void determineVersion(String localPomVersion) {

--- a/service-clients-gen/src/main/java/com/flipkart/poseidon/serviceclients/generator/Generator.java
+++ b/service-clients-gen/src/main/java/com/flipkart/poseidon/serviceclients/generator/Generator.java
@@ -40,7 +40,7 @@ public class Generator {
     private final static String IDL_BASE_PATH = ".src.main.resources.idl.";
     private final static String POJO_FOLDER_NAME = "pojos";
     private final static String SERVICE_FOLDER_NAME = "service";
-    private final static String DEFAULT_SERVICE_CLIENT_GROUP_ID="com.flipkart.poseidon.serviceclients";
+    private final static String DEFAULT_SERVICE_CLIENT_GROUP_ID = "com.flipkart.poseidon.serviceclients";
     private final static String DESTINATION_JAVA_FOLDER = ".target.generated-sources.";
     private final static JCodeModel jCodeModel = new JCodeModel();
     private final static Logger logger = LoggerFactory.getLogger(Generator.class);
@@ -94,12 +94,20 @@ public class Generator {
             serviceClientGroupId = DEFAULT_SERVICE_CLIENT_GROUP_ID;
         }
 
+        validateServiceClientGroupId(serviceClientGroupId);
         packageName = trimmedPackageName(serviceClientGroupId) + "." + moduleName + "." + majorVersion;
 
         if (args.length > 2) {
             pojoOrdering = args[2].split(",");
         }
         return true;
+    }
+
+    private static void validateServiceClientGroupId(String groupId) {
+        if (!groupId.matches("^([a-zA-Z_]+[.])*([a-zA-Z_]+)$")) {
+            logger.error("Invalid value for property service.clients.groupId");
+            System.exit(-1);
+        }
     }
 
     private static String trimmedPackageName(String pkgName){

--- a/service-clients-gen/src/main/java/com/flipkart/poseidon/serviceclients/generator/Generator.java
+++ b/service-clients-gen/src/main/java/com/flipkart/poseidon/serviceclients/generator/Generator.java
@@ -107,7 +107,7 @@ public class Generator {
 
     private static void validateServiceClientGroupId(String groupId) {
         if (!groupId.matches(SERVICE_CLIENT_GROUP_ID_REGEX)) {
-            logger.error("Invalid value for property service.clients.groupId");
+            logger.error("Invalid value for property {}", SERVICE_CLIENT_GROUP_ID_KEY);
             System.exit(-1);
         }
     }

--- a/service-clients-gen/src/main/java/com/flipkart/poseidon/serviceclients/generator/Generator.java
+++ b/service-clients-gen/src/main/java/com/flipkart/poseidon/serviceclients/generator/Generator.java
@@ -40,8 +40,8 @@ public class Generator {
     private final static String IDL_BASE_PATH = ".src.main.resources.idl.";
     private final static String POJO_FOLDER_NAME = "pojos";
     private final static String SERVICE_FOLDER_NAME = "service";
+    private final static String DEFAULT_SERVICE_CLIENT_GROUP_ID="com.flipkart.poseidon.serviceclients";
     private final static String DESTINATION_JAVA_FOLDER = ".target.generated-sources.";
-    private final static String PACKAGE_NAME = "com.flipkart.poseidon.serviceclients."; // module name and major version will be appended to this
     private final static JCodeModel jCodeModel = new JCodeModel();
     private final static Logger logger = LoggerFactory.getLogger(Generator.class);
 
@@ -88,12 +88,22 @@ public class Generator {
 
         determineVersion(args[1]);
         String majorVersion = "v" + version.getMajor();
-        packageName = PACKAGE_NAME + moduleName + "." + majorVersion;
+
+        String serviceClientGroupId = System.getProperty("service.clients.groupId");
+        if (serviceClientGroupId == null || serviceClientGroupId.isEmpty()) {
+            serviceClientGroupId = DEFAULT_SERVICE_CLIENT_GROUP_ID;
+        }
+
+        packageName = trimmedPackageName(serviceClientGroupId) + "." + moduleName + "." + majorVersion;
 
         if (args.length > 2) {
             pojoOrdering = args[2].split(",");
         }
         return true;
+    }
+
+    private static String trimmedPackageName(String pkgName){
+        return pkgName.endsWith(".") ? pkgName.substring(0, pkgName.length() - 2) : pkgName;
     }
 
     private static void determineVersion(String localPomVersion) {


### PR DESCRIPTION
By default service clients generated by this Generator group them in package **com.flipkart.poseidon.serviceclients**. As it is an open-source project, developers should have the flexibility to provide their own package group name as per their needs.
This change will let them use their own group id e.g. **com.companyname.serviceclients** instead of the default one.
In the case of groupId is not provided it will use the default groupId as **com.flipkart.poseidon.serviceclients**

Usage:
`mvn clean install -Dservice.clients.groupId=com.companyname.serviceclients`