### PR TITLE
Multipart form support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.9.0 (WIP)
+## 5.9.0 (Aug 5, 2020)
 - Added Rotation APIs for managing state of the container
 - Support for custom Servlets
 - Support for injectable singleton DataSources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [SchemaGenerator] Support for optional request body and file types
 - [SchemaGenerator] Support for collections as request bodies
 - [Bugfix] React correctly when we do not parse empty strings as params
+- Custom group id for generated service clients
 
 ## 5.8.0 (May 5, 2019)
 - Support for byte[] in ServiceResponseDecoder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.11.0 (Sep 11, 2020)
+- Support for multipart forms in ServiceClients
+- Support for session management
+- Added type safe execute Sync and Async methods in AbstractDataSource
+
 ## 5.10.0 (Sep 2, 2020)
 - Upgrade to Spring 5.2.5.RELEASE
 - Upgrade to Phantom 3.5.0

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Poseidon is a platform to build API applications that have to aggregate data fro
 
 | Release | Date | Description |
 |:------------|:----------------|:------------|
+| Version 5.11.0            | Sep 11 2020      |    Support for multipart forms in ServiceClients and session management
 | Version 5.10.0            | Sep 02 2020      |    Upgrade to Spring 5.2.5.RELEASE
 | Version 5.9.0             | Aug 05 2020      |    Custom servlets, singleton DS, bug fixes
 | Version 5.8.0             | May 31 2019      |    Support for byte[] in ServiceResponseDecoder

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ Poseidon is a platform to build API applications that have to aggregate data fro
 
 | Release | Date | Description |
 |:------------|:----------------|:------------|
+| Version 5.9.0             | Aug 05 2020      |    Custom servlets, singleton DS, bug fixes
+
 | Version 5.8.0             | May 31 2019      |    Support for byte[] in ServiceResponseDecoder
 | Version 5.6.0             | Jun 28 2018      |    Multiple error types in ServiceResponseDecoder
 | Version 5.5.0             | May 23 2018      |    Added follow redirect option in SinglePoolHttpTaskHandler
 | Version 5.4.1             | Nov 05 2017      |    Bugfix to stop stacktrace leak
-| Version 5.4.0             | Oct 13 2017      |    Support for DataTypes in headers, path params and support for enums and generics in API definitions
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Poseidon is a platform to build API applications that have to aggregate data fro
 | Release | Date | Description |
 |:------------|:----------------|:------------|
 | Version 5.9.0             | Aug 05 2020      |    Custom servlets, singleton DS, bug fixes
-
 | Version 5.8.0             | May 31 2019      |    Support for byte[] in ServiceResponseDecoder
 | Version 5.6.0             | Jun 28 2018      |    Multiple error types in ServiceResponseDecoder
 | Version 5.5.0             | May 23 2018      |    Added follow redirect option in SinglePoolHttpTaskHandler

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0-SNAPSHOT</version>
+        <version>5.9.0</version>
     </parent>
 
     <artifactId>api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.11.0-SNAPSHOT</version>
+        <version>5.11.0</version>
     </parent>
 
     <artifactId>api</artifactId>

--- a/cadfael-maven-plugin/pom.xml
+++ b/cadfael-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.11.0-SNAPSHOT</version>
+        <version>5.11.0</version>
     </parent>
 
     <artifactId>cadfael-maven-plugin</artifactId>

--- a/cadfael-maven-plugin/pom.xml
+++ b/cadfael-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0-SNAPSHOT</version>
+        <version>5.9.0</version>
     </parent>
 
     <artifactId>cadfael-maven-plugin</artifactId>

--- a/cadfael-maven-plugin/pom.xml
+++ b/cadfael-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cadfael-maven-plugin</artifactId>

--- a/cadfael-maven-plugin/pom.xml
+++ b/cadfael-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cadfael-maven-plugin</artifactId>

--- a/cadfael/pom.xml
+++ b/cadfael/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0-SNAPSHOT</version>
+        <version>5.9.0</version>
     </parent>
 
     <artifactId>cadfael</artifactId>

--- a/cadfael/pom.xml
+++ b/cadfael/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cadfael</artifactId>

--- a/cadfael/pom.xml
+++ b/cadfael/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.11.0-SNAPSHOT</version>
+        <version>5.11.0</version>
     </parent>
 
     <artifactId>cadfael</artifactId>

--- a/cadfael/pom.xml
+++ b/cadfael/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cadfael</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>common</artifactId>
@@ -22,5 +22,5 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
     </dependencies>
-    
+
 </project>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0-SNAPSHOT</version>
+        <version>5.9.0</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.11.0-SNAPSHOT</version>
+        <version>5.11.0</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.11.0-SNAPSHOT</version>
+        <version>5.11.0</version>
     </parent>
 
     <artifactId>container</artifactId>

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>container</artifactId>

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>container</artifactId>

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0-SNAPSHOT</version>
+        <version>5.9.0</version>
     </parent>
 
     <artifactId>container</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0-SNAPSHOT</version>
+        <version>5.9.0</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.11.0-SNAPSHOT</version>
+        <version>5.11.0</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/http-handler/pom.xml
+++ b/http-handler/pom.xml
@@ -26,10 +26,10 @@
             <artifactId>validation-api</artifactId>
             <version>1.1.0.Final</version>
         </dependency>
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpmime</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpmime</artifactId>
+        </dependency>
 	</dependencies>
 
 </project>

--- a/http-handler/pom.xml
+++ b/http-handler/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.flipkart.poseidon</groupId>
 		<artifactId>poseidon</artifactId>
-		<version>5.9.0-SNAPSHOT</version>
+		<version>5.9.0</version>
 	</parent>
 
 	<artifactId>http-handler</artifactId>

--- a/http-handler/pom.xml
+++ b/http-handler/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.flipkart.poseidon</groupId>
 		<artifactId>poseidon</artifactId>
-		<version>5.9.0</version>
+		<version>6.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>http-handler</artifactId>
@@ -26,6 +26,10 @@
             <artifactId>validation-api</artifactId>
             <version>1.1.0.Final</version>
         </dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpmime</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/http-handler/pom.xml
+++ b/http-handler/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.flipkart.poseidon</groupId>
 		<artifactId>poseidon</artifactId>
-		<version>5.11.0-SNAPSHOT</version>
+		<version>5.11.0</version>
 	</parent>
 
 	<artifactId>http-handler</artifactId>

--- a/http-handler/pom.xml
+++ b/http-handler/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.flipkart.poseidon</groupId>
 		<artifactId>poseidon</artifactId>
-		<version>6.0.0-SNAPSHOT</version>
+		<version>5.10.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>http-handler</artifactId>

--- a/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/HandlerConstants.java
+++ b/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/HandlerConstants.java
@@ -25,6 +25,7 @@ public class HandlerConstants {
     public static final String HTTP_URI = "uri";
     public static final String HTTP_METHOD = "method";
     public static final String HTTP_HEADERS = "headers";
+    public static final String HTTP_FORM_FIELDS = "formFields";
 
     public static final String X_CACHE_REQUEST = "X-Cache-Request";
 }

--- a/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/HttpConnectionPool.java
+++ b/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/HttpConnectionPool.java
@@ -337,15 +337,15 @@ public class HttpConnectionPool {
         } else if ("POST".equals(requestType))
         {
             HttpPost request = new HttpPost(constructUrl(uri));
-            setRequestBody(request,data, formFields);
             setRequestHeaders(request, requestHeaders);
+            setRequestBody(request,data, formFields);
             return request;
 
         } else if ("PUT".equals(requestType))
         {
             HttpPut request = new HttpPut(constructUrl(uri));
-            setRequestBody(request,data, formFields);
             setRequestHeaders(request, requestHeaders);
+            setRequestBody(request,data, formFields);
             return request;
 
         } else if ("DELETE".equals(requestType))
@@ -387,7 +387,6 @@ public class HttpConnectionPool {
         if(CollectionUtils.isEmpty(formFields)) {
             setRequestBody(request, data);
         } else {
-//            request.setHeader("Content-Type", ContentType.MULTIPART_FORM_DATA.getMimeType());
             MultipartEntityBuilder multipartEntityBuilder = MultipartEntityBuilder.create();
             formFields.forEach(formField -> {
                 if(formField instanceof FileFormField) {
@@ -397,7 +396,9 @@ public class HttpConnectionPool {
                     multipartEntityBuilder.addTextBody(formField.getName(), new String(formField.getData()), formField.getContentType());
                 }
             });
-            request.setEntity(multipartEntityBuilder.build());
+            HttpEntity httpEntity = multipartEntityBuilder.build();
+            request.setEntity(httpEntity);
+            request.setHeader(httpEntity.getContentType());
         }
     }
 

--- a/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/HttpConnectionPool.java
+++ b/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/HttpConnectionPool.java
@@ -16,6 +16,8 @@
 
 package com.flipkart.poseidon.handlers.http.impl;
 
+import com.flipkart.poseidon.handlers.http.multipart.FileFormField;
+import com.flipkart.poseidon.handlers.http.multipart.FormField;
 import com.flipkart.poseidon.handlers.http.HttpDelete;
 import org.apache.http.*;
 import org.apache.http.client.HttpClient;
@@ -31,6 +33,7 @@ import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.scheme.SchemeRegistry;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.PoolingClientConnectionManager;
 import org.apache.http.params.BasicHttpParams;
@@ -38,6 +41,7 @@ import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.pool.PoolStats;
 import org.apache.http.protocol.HttpContext;
+import org.springframework.util.CollectionUtils;
 import org.trpr.platform.core.impl.logging.LogFactory;
 import org.trpr.platform.core.spi.logging.Logger;
 
@@ -257,7 +261,7 @@ public class HttpConnectionPool {
         setRequestHeaders(request, requestHeaders);
         return execute(request);
     }
-    
+
     /**
      * Method for executing HTTP DELETE request
      */
@@ -322,8 +326,8 @@ public class HttpConnectionPool {
     /**
      * Method to create HttpRequest
      */
-
-    public HttpRequestBase createHttpRequest(String uri, byte[] data, Map<String, String> requestHeaders, String requestType)
+    public HttpRequestBase createHttpRequest(String uri, byte[] data, Map<String, String> requestHeaders,
+                                             String requestType, List<FormField> formFields)
     {
         if("GET".equals(requestType))
         {
@@ -333,14 +337,14 @@ public class HttpConnectionPool {
         } else if ("POST".equals(requestType))
         {
             HttpPost request = new HttpPost(constructUrl(uri));
-            setRequestBody(request,data);
+            setRequestBody(request,data, formFields);
             setRequestHeaders(request, requestHeaders);
             return request;
 
         } else if ("PUT".equals(requestType))
         {
             HttpPut request = new HttpPut(constructUrl(uri));
-            setRequestBody(request,data);
+            setRequestBody(request,data, formFields);
             setRequestHeaders(request, requestHeaders);
             return request;
 
@@ -363,7 +367,6 @@ public class HttpConnectionPool {
             return request;
         }
     }
-
     /**
      *
      * @param request
@@ -377,6 +380,24 @@ public class HttpConnectionPool {
             } else {
                 request.setEntity(new ByteArrayEntity(data));
             }
+        }
+    }
+
+    private void setRequestBody(HttpEntityEnclosingRequestBase request, byte[] data, List<FormField> formFields) {
+        if(CollectionUtils.isEmpty(formFields)) {
+            setRequestBody(request, data);
+        } else {
+//            request.setHeader("Content-Type", ContentType.MULTIPART_FORM_DATA.getMimeType());
+            MultipartEntityBuilder multipartEntityBuilder = MultipartEntityBuilder.create();
+            formFields.forEach(formField -> {
+                if(formField instanceof FileFormField) {
+                    multipartEntityBuilder.addBinaryBody(formField.getName(), formField.getData(),
+                            formField.getContentType(), ((FileFormField) formField).getFileName());
+                } else {
+                    multipartEntityBuilder.addTextBody(formField.getName(), new String(formField.getData()), formField.getContentType());
+                }
+            });
+            request.setEntity(multipartEntityBuilder.build());
         }
     }
 

--- a/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/SinglePoolHttpTaskHandler.java
+++ b/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/SinglePoolHttpTaskHandler.java
@@ -277,12 +277,13 @@ public class SinglePoolHttpTaskHandler extends RequestCacheableHystrixTaskHandle
         return makeRequest(method, uri, data, requestHeaders, Collections.emptyList());
     }
     /**
-     * This makes the call to the service via the Http Client Framework
+     * This makes the call to the service via the Http Client Framework having form fields option
      *
      * @param method
      * @param uri
      * @param data
      * @param requestHeaders
+     * @param formFields
      * @return
      * @throws Exception
      */

--- a/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/SinglePoolHttpTaskHandler.java
+++ b/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/impl/SinglePoolHttpTaskHandler.java
@@ -24,6 +24,7 @@ import com.flipkart.phantom.task.spi.Decoder;
 import com.flipkart.phantom.task.spi.TaskContext;
 import com.flipkart.poseidon.handlers.http.HttpResponseDecoder;
 import com.flipkart.poseidon.handlers.http.HttpResponseData;
+import com.flipkart.poseidon.handlers.http.multipart.FormField;
 import com.google.common.base.Charsets;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
@@ -35,15 +36,13 @@ import org.apache.http.util.EntityUtils;
 import org.trpr.platform.core.impl.logging.LogFactory;
 import org.trpr.platform.core.spi.logging.Logger;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import static com.flipkart.poseidon.handlers.http.HandlerConstants.*;
 import static com.google.common.hash.Hashing.murmur3_32;
-
-import static com.flipkart.poseidon.handlers.http.HandlerConstants.HTTP_HEADERS;
-import static com.flipkart.poseidon.handlers.http.HandlerConstants.HTTP_METHOD;
-import static com.flipkart.poseidon.handlers.http.HandlerConstants.HTTP_URI;
-import static com.flipkart.poseidon.handlers.http.HandlerConstants.X_CACHE_REQUEST;
 
 
 public class SinglePoolHttpTaskHandler extends RequestCacheableHystrixTaskHandler {
@@ -148,7 +147,8 @@ public class SinglePoolHttpTaskHandler extends RequestCacheableHystrixTaskHandle
         }
 
         try {
-            HttpRequestBase request = this.pool.createHttpRequest((String) params.get(HTTP_URI), data, requestHeaders, (String) params.get(HTTP_METHOD));
+            HttpRequestBase request = this.pool.createHttpRequest((String) params.get(HTTP_URI), data,
+                    requestHeaders, (String) params.get(HTTP_METHOD), (List<FormField>) params.get(HTTP_FORM_FIELDS));
             HttpResponse httpResponse =  this.pool.execute(request);
 
             return  new TaskResult<T>(true, null, ((HttpResponseDecoder<T>) decoder).decode(httpResponse));
@@ -181,7 +181,8 @@ public class SinglePoolHttpTaskHandler extends RequestCacheableHystrixTaskHandle
         }
         TaskResult result;
         try {
-            result  = handleHttpResponse(makeRequest((String) params.get(HTTP_METHOD), (String) params.get(HTTP_URI), (byte[]) data, requestHeaders));
+            result  = handleHttpResponse(makeRequest((String) params.get(HTTP_METHOD), (String) params.get(HTTP_URI),
+                    (byte[]) data, requestHeaders, (List<FormField>) params.get(HTTP_FORM_FIELDS)));
         }
         catch (Exception e) {
             result =  handleException(e, (String) params.get(HTTP_URI), (String) params.get(HTTP_METHOD));
@@ -273,7 +274,21 @@ public class SinglePoolHttpTaskHandler extends RequestCacheableHystrixTaskHandle
      */
     protected final HttpResponseData makeRequest(String method, String uri, byte[] data,
                                                  Map<String,String> requestHeaders) throws Exception{
-        HttpRequestBase request = this.pool.createHttpRequest(uri, data, requestHeaders, method);
+        return makeRequest(method, uri, data, requestHeaders, Collections.emptyList());
+    }
+    /**
+     * This makes the call to the service via the Http Client Framework
+     *
+     * @param method
+     * @param uri
+     * @param data
+     * @param requestHeaders
+     * @return
+     * @throws Exception
+     */
+    protected final HttpResponseData makeRequest(String method, String uri, byte[] data,
+                                                 Map<String,String> requestHeaders, List<FormField> formFields) throws Exception{
+        HttpRequestBase request = this.pool.createHttpRequest(uri, data, requestHeaders, method, formFields);
         return getHttpResponseData(this.pool.execute(request));
     }
 

--- a/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/multipart/FileFormField.java
+++ b/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/multipart/FileFormField.java
@@ -1,0 +1,20 @@
+package com.flipkart.poseidon.handlers.http.multipart;
+
+import org.apache.http.entity.ContentType;
+
+/**
+ * Created by chaitanya.naik on 2020-08-18.
+ */
+public class FileFormField extends FormField {
+
+    private String fileName;
+
+    public FileFormField(String name, ContentType contentType, byte[] data, String fileName) {
+        super(name, contentType, data);
+        this.fileName = fileName;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+}

--- a/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/multipart/FormField.java
+++ b/http-handler/src/main/java/com/flipkart/poseidon/handlers/http/multipart/FormField.java
@@ -1,0 +1,34 @@
+package com.flipkart.poseidon.handlers.http.multipart;
+
+import org.apache.http.entity.ContentType;
+
+/**
+ * Created by chaitanya.naik on 2020-08-17.
+ */
+public class FormField {
+    private String name;
+    private ContentType contentType;
+    private byte[] data;
+
+    public FormField(String name, ContentType contentType, byte[] data) {
+        this.name = name;
+        this.contentType = contentType;
+        this.data = data;
+    }
+
+    public FormField(String name, ContentType contentType, String data) {
+        this(name, contentType, data.getBytes());
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ContentType getContentType() {
+        return contentType;
+    }
+
+    public byte[] getData() {
+        return data;
+    }
+}

--- a/log4j-access/pom.xml
+++ b/log4j-access/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>log4j-access</artifactId>

--- a/log4j-access/pom.xml
+++ b/log4j-access/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>log4j-access</artifactId>

--- a/log4j-access/pom.xml
+++ b/log4j-access/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0-SNAPSHOT</version>
+        <version>5.9.0</version>
     </parent>
 
     <artifactId>log4j-access</artifactId>

--- a/log4j-access/pom.xml
+++ b/log4j-access/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.11.0-SNAPSHOT</version>
+        <version>5.11.0</version>
     </parent>
 
     <artifactId>log4j-access</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.flipkart.poseidon</groupId>
     <artifactId>poseidon</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
 
     <name>Poseidon</name>
     <description>A platform to build API applications that have to aggregate data from distributed services in an efficient way</description>

--- a/pom.xml
+++ b/pom.xml
@@ -424,15 +424,10 @@
     </repositories>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>fk-art-snapshot</id>
-            <name>FK ART - Snapshots</name>
-            <url>http://artifactory.fkinternal.com/artifactory/v1.0/artifacts/libs-snapshots-local</url>
-        </snapshotRepository>
         <repository>
-            <id>fk-art-release</id>
-            <name>FK ART - Releases</name>
-            <url>http://artifactory.fkinternal.com/artifactory/v1.0/artifacts/libs-release-local</url>
+            <id>clojars</id>
+            <name>Clojars repository</name>
+            <url>https://clojars.org/repo</url>
         </repository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.flipkart.poseidon</groupId>
     <artifactId>poseidon</artifactId>
-    <version>5.11.0-SNAPSHOT</version>
+    <version>5.11.0</version>
 
     <name>Poseidon</name>
     <description>A platform to build API applications that have to aggregate data from distributed services in an efficient way</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.flipkart.poseidon</groupId>
     <artifactId>poseidon</artifactId>
-    <version>5.9.0-SNAPSHOT</version>
+    <version>5.9.0</version>
 
     <name>Poseidon</name>
     <description>A platform to build API applications that have to aggregate data from distributed services in an efficient way</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.flipkart.poseidon</groupId>
     <artifactId>poseidon</artifactId>
-    <version>5.9.0</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <name>Poseidon</name>
     <description>A platform to build API applications that have to aggregate data from distributed services in an efficient way</description>
@@ -118,6 +118,11 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
+                <version>4.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpmime</artifactId>
                 <version>4.3</version>
             </dependency>
 

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>poseidon</artifactId>
         <groupId>com.flipkart.poseidon</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample</artifactId>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>poseidon</artifactId>
         <groupId>com.flipkart.poseidon</groupId>
-        <version>5.9.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample</artifactId>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>poseidon</artifactId>
         <groupId>com.flipkart.poseidon</groupId>
-        <version>5.11.0-SNAPSHOT</version>
+        <version>5.11.0</version>
     </parent>
 
     <artifactId>sample</artifactId>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>poseidon</artifactId>
         <groupId>com.flipkart.poseidon</groupId>
-        <version>5.9.0-SNAPSHOT</version>
+        <version>5.9.0</version>
     </parent>
 
     <artifactId>sample</artifactId>

--- a/sample/src/main/java/com/flipkart/poseidon/sample/datasources/CommentsDataSource.java
+++ b/sample/src/main/java/com/flipkart/poseidon/sample/datasources/CommentsDataSource.java
@@ -24,7 +24,7 @@ import com.flipkart.poseidon.model.annotations.Version;
 import com.flipkart.poseidon.sample.datatypes.CommentDataType;
 import com.flipkart.poseidon.sample.datatypes.PostDataType;
 import com.flipkart.poseidon.sample.datatypes.PostWithCommentsDataType;
-import com.flipkart.poseidon.serviceclients.sampleSC.v6.*;
+import com.flipkart.poseidon.serviceclients.sampleSC.v5.*;
 import flipkart.lego.api.entities.LegoSet;
 import flipkart.lego.api.entities.Request;
 import org.slf4j.Logger;

--- a/sample/src/main/java/com/flipkart/poseidon/sample/datasources/CommentsDataSource.java
+++ b/sample/src/main/java/com/flipkart/poseidon/sample/datasources/CommentsDataSource.java
@@ -24,7 +24,7 @@ import com.flipkart.poseidon.model.annotations.Version;
 import com.flipkart.poseidon.sample.datatypes.CommentDataType;
 import com.flipkart.poseidon.sample.datatypes.PostDataType;
 import com.flipkart.poseidon.sample.datatypes.PostWithCommentsDataType;
-import com.flipkart.poseidon.serviceclients.sampleSC.v5.*;
+import com.flipkart.poseidon.serviceclients.sampleSC.v6.*;
 import flipkart.lego.api.entities.LegoSet;
 import flipkart.lego.api.entities.Request;
 import org.slf4j.Logger;

--- a/sample/src/main/java/com/flipkart/poseidon/sample/datasources/PostsDataSource.java
+++ b/sample/src/main/java/com/flipkart/poseidon/sample/datasources/PostsDataSource.java
@@ -23,7 +23,7 @@ import com.flipkart.poseidon.model.annotations.Name;
 import com.flipkart.poseidon.model.annotations.Version;
 import com.flipkart.poseidon.sample.datatypes.PostDataType;
 import com.flipkart.poseidon.sample.datatypes.PostsDataType;
-import com.flipkart.poseidon.serviceclients.sampleSC.v6.*;
+import com.flipkart.poseidon.serviceclients.sampleSC.v5.*;
 import flipkart.lego.api.entities.LegoSet;
 import flipkart.lego.api.entities.Request;
 import org.slf4j.Logger;

--- a/sample/src/main/java/com/flipkart/poseidon/sample/datasources/PostsDataSource.java
+++ b/sample/src/main/java/com/flipkart/poseidon/sample/datasources/PostsDataSource.java
@@ -23,7 +23,7 @@ import com.flipkart.poseidon.model.annotations.Name;
 import com.flipkart.poseidon.model.annotations.Version;
 import com.flipkart.poseidon.sample.datatypes.PostDataType;
 import com.flipkart.poseidon.sample.datatypes.PostsDataType;
-import com.flipkart.poseidon.serviceclients.sampleSC.v5.*;
+import com.flipkart.poseidon.serviceclients.sampleSC.v6.*;
 import flipkart.lego.api.entities.LegoSet;
 import flipkart.lego.api.entities.Request;
 import org.slf4j.Logger;

--- a/sample/src/main/java/com/flipkart/poseidon/sample/datasources/UserDataSource.java
+++ b/sample/src/main/java/com/flipkart/poseidon/sample/datasources/UserDataSource.java
@@ -22,7 +22,7 @@ import com.flipkart.poseidon.model.annotations.Description;
 import com.flipkart.poseidon.model.annotations.Name;
 import com.flipkart.poseidon.model.annotations.Version;
 import com.flipkart.poseidon.sample.datatypes.UserDataType;
-import com.flipkart.poseidon.serviceclients.sampleSC.v6.*;
+import com.flipkart.poseidon.serviceclients.sampleSC.v5.*;
 import flipkart.lego.api.entities.LegoSet;
 import flipkart.lego.api.entities.Request;
 import org.slf4j.Logger;

--- a/sample/src/main/java/com/flipkart/poseidon/sample/datasources/UserDataSource.java
+++ b/sample/src/main/java/com/flipkart/poseidon/sample/datasources/UserDataSource.java
@@ -22,7 +22,7 @@ import com.flipkart.poseidon.model.annotations.Description;
 import com.flipkart.poseidon.model.annotations.Name;
 import com.flipkart.poseidon.model.annotations.Version;
 import com.flipkart.poseidon.sample.datatypes.UserDataType;
-import com.flipkart.poseidon.serviceclients.sampleSC.v5.*;
+import com.flipkart.poseidon.serviceclients.sampleSC.v6.*;
 import flipkart.lego.api.entities.LegoSet;
 import flipkart.lego.api.entities.Request;
 import org.slf4j.Logger;

--- a/sampleSC/pom.xml
+++ b/sampleSC/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>poseidon</artifactId>
         <groupId>com.flipkart.poseidon</groupId>
-        <version>5.9.0-SNAPSHOT</version>
+        <version>5.9.0</version>
     </parent>
 
     <artifactId>sampleSC</artifactId>

--- a/sampleSC/pom.xml
+++ b/sampleSC/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>poseidon</artifactId>
         <groupId>com.flipkart.poseidon</groupId>
-        <version>5.11.0-SNAPSHOT</version>
+        <version>5.11.0</version>
     </parent>
 
     <artifactId>sampleSC</artifactId>

--- a/sampleSC/pom.xml
+++ b/sampleSC/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>poseidon</artifactId>
         <groupId>com.flipkart.poseidon</groupId>
-        <version>5.9.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sampleSC</artifactId>

--- a/sampleSC/pom.xml
+++ b/sampleSC/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>poseidon</artifactId>
         <groupId>com.flipkart.poseidon</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sampleSC</artifactId>

--- a/sampleSC/src/main/resources/idl/service/SampleService.json
+++ b/sampleSC/src/main/resources/idl/service/SampleService.json
@@ -23,6 +23,22 @@
       "description": [
         "Unique ID of post to get all comments"
       ]
+    },
+    "userData": {
+      "type": "String",
+      "formFieldType" : "TEXT",
+      "formFieldContentType" : "application/json",
+      "description" : [
+        "User details as json string"
+      ]
+    },
+    "avatar": {
+      "type": "byte[]",
+      "formFieldType" : "FILE",
+      "formFieldContentType" : "image/jpeg",
+      "description" : [
+        "User's display picture"
+      ]
     }
   },
   "endPoints": {
@@ -60,6 +76,21 @@
       "responseObject": "Comments",
       "description": [
         "Fetches all comments of a post"
+      ]
+    },
+    "createUser": {
+      "httpMethod": "POST",
+      "uri": "/users",
+      "headers": {
+        "Content-Type":"multipart/form-data"
+      },
+      "responseObject": "User",
+      "parameters": [
+        "userData",
+        "avatar"
+      ],
+      "description": [
+        "Dummy create user api"
       ]
     }
   },

--- a/service-clients-archetype/pom.xml
+++ b/service-clients-archetype/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-clients-archetype</artifactId>

--- a/service-clients-archetype/pom.xml
+++ b/service-clients-archetype/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-clients-archetype</artifactId>

--- a/service-clients-archetype/pom.xml
+++ b/service-clients-archetype/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.11.0-SNAPSHOT</version>
+        <version>5.11.0</version>
     </parent>
 
     <artifactId>service-clients-archetype</artifactId>

--- a/service-clients-archetype/pom.xml
+++ b/service-clients-archetype/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0-SNAPSHOT</version>
+        <version>5.9.0</version>
     </parent>
 
     <artifactId>service-clients-archetype</artifactId>

--- a/service-clients-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/service-clients-archetype/src/main/resources/archetype-resources/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.flipkart.poseidon</groupId>
             <artifactId>service-clients-core</artifactId>
-            <version>6.0.0-SNAPSHOT</version>
+            <version>5.10.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
@@ -51,12 +51,12 @@
                     <dependency>
                         <groupId>com.flipkart.poseidon</groupId>
                         <artifactId>service-clients-core</artifactId>
-                        <version>6.0.0-SNAPSHOT</version>
+                        <version>5.10.0-SNAPSHOT</version>
                     </dependency>
                     <dependency>
                         <groupId>com.flipkart.poseidon</groupId>
                         <artifactId>service-clients-gen</artifactId>
-                        <version>6.0.0-SNAPSHOT</version>
+                        <version>5.10.0-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/service-clients-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/service-clients-archetype/src/main/resources/archetype-resources/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.flipkart.poseidon</groupId>
             <artifactId>service-clients-core</artifactId>
-            <version>5.9.0-SNAPSHOT</version>
+            <version>5.9.0</version>
         </dependency>
     </dependencies>
 
@@ -51,12 +51,12 @@
                     <dependency>
                         <groupId>com.flipkart.poseidon</groupId>
                         <artifactId>service-clients-core</artifactId>
-                        <version>5.9.0-SNAPSHOT</version>
+                        <version>5.9.0</version>
                     </dependency>
                     <dependency>
                         <groupId>com.flipkart.poseidon</groupId>
                         <artifactId>service-clients-gen</artifactId>
-                        <version>5.9.0-SNAPSHOT</version>
+                        <version>5.9.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/service-clients-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/service-clients-archetype/src/main/resources/archetype-resources/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.flipkart.poseidon</groupId>
             <artifactId>service-clients-core</artifactId>
-            <version>5.11.0-SNAPSHOT</version>
+            <version>5.11.0</version>
         </dependency>
     </dependencies>
 
@@ -51,12 +51,12 @@
                     <dependency>
                         <groupId>com.flipkart.poseidon</groupId>
                         <artifactId>service-clients-core</artifactId>
-                        <version>5.11.0-SNAPSHOT</version>
+                        <version>5.11.0</version>
                     </dependency>
                     <dependency>
                         <groupId>com.flipkart.poseidon</groupId>
                         <artifactId>service-clients-gen</artifactId>
-                        <version>5.11.0-SNAPSHOT</version>
+                        <version>5.11.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/service-clients-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/service-clients-archetype/src/main/resources/archetype-resources/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.flipkart.poseidon</groupId>
             <artifactId>service-clients-core</artifactId>
-            <version>5.9.0</version>
+            <version>6.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
@@ -51,12 +51,12 @@
                     <dependency>
                         <groupId>com.flipkart.poseidon</groupId>
                         <artifactId>service-clients-core</artifactId>
-                        <version>5.9.0</version>
+                        <version>6.0.0-SNAPSHOT</version>
                     </dependency>
                     <dependency>
                         <groupId>com.flipkart.poseidon</groupId>
                         <artifactId>service-clients-gen</artifactId>
-                        <version>5.9.0</version>
+                        <version>6.0.0-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/service-clients-core/pom.xml
+++ b/service-clients-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.11.0-SNAPSHOT</version>
+        <version>5.11.0</version>
     </parent>
 
     <artifactId>service-clients-core</artifactId>

--- a/service-clients-core/pom.xml
+++ b/service-clients-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-clients-core</artifactId>

--- a/service-clients-core/pom.xml
+++ b/service-clients-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-clients-core</artifactId>

--- a/service-clients-core/pom.xml
+++ b/service-clients-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0-SNAPSHOT</version>
+        <version>5.9.0</version>
     </parent>
 
     <artifactId>service-clients-core</artifactId>

--- a/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/AbstractServiceClient.java
+++ b/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/AbstractServiceClient.java
@@ -28,7 +28,6 @@ import com.flipkart.poseidon.handlers.http.multipart.FormField;
 import com.flipkart.poseidon.model.VariableModel;
 import flipkart.lego.api.entities.ServiceClient;
 import flipkart.lego.api.exceptions.LegoServiceException;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
@@ -319,10 +318,6 @@ public abstract class AbstractServiceClient implements ServiceClient {
         }
 
         return objectMapper.getTypeFactory().constructParametrizedType(clazz, clazz, javaTypes);
-    }
-
-    protected <T> void validateNotEmpty(T[] a) {
-        ArrayUtils.isNotEmpty(a);
     }
 
     @Override

--- a/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/AbstractServiceClient.java
+++ b/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/AbstractServiceClient.java
@@ -29,13 +29,11 @@ import com.flipkart.poseidon.model.VariableModel;
 import flipkart.lego.api.entities.ServiceClient;
 import flipkart.lego.api.exceptions.LegoServiceException;
 import org.apache.commons.lang3.ClassUtils;
-import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.List;
@@ -194,26 +192,6 @@ public abstract class AbstractServiceClient implements ServiceClient {
             return String.valueOf(url);
         } else {
             return encodeUrl(objectMapper.writeValueAsString(url));
-        }
-    }
-
-    protected String encodePathParam(Object path) throws JsonProcessingException {
-        String stringifiedPath;
-
-        if (path == null) {
-            stringifiedPath = "";
-        } else if (path instanceof String) {
-            stringifiedPath = (String) path;
-        } else if (ClassUtils.isPrimitiveOrWrapper(path.getClass()) || path.getClass().isEnum()) {
-            stringifiedPath = String.valueOf(path);
-        } else {
-            stringifiedPath = objectMapper.writeValueAsString(path);
-        }
-        try {
-            return new URIBuilder().setPath(stringifiedPath).build().toString();
-        } catch (URISyntaxException e) {
-            LoggerFactory.getLogger(getClass()).error("Exception while encoding Path param: " + stringifiedPath, e);
-            return stringifiedPath;
         }
     }
 

--- a/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/ServiceExecuteProperties.java
+++ b/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/ServiceExecuteProperties.java
@@ -17,8 +17,11 @@
 package com.flipkart.poseidon.serviceclients;
 
 import com.fasterxml.jackson.databind.JavaType;
+import com.flipkart.poseidon.handlers.http.multipart.FormField;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -34,6 +37,7 @@ public class ServiceExecuteProperties {
     private String commandName;
     private boolean requestCachingEnabled;
     private Map<String, ServiceResponseInfo> serviceResponseInfoMap = new HashMap<>();
+    private List<FormField> formFields = new ArrayList<>();
 
     public JavaType getJavaType() {
         return javaType;
@@ -106,4 +110,13 @@ public class ServiceExecuteProperties {
     public void setServiceResponseInfoMap(Map<String, ServiceResponseInfo> serviceResponseInfoMap) {
         this.serviceResponseInfoMap = serviceResponseInfoMap;
     }
+
+    public List<FormField> getFormFields() {
+        return formFields;
+    }
+
+    public void setFormFields(List<FormField> formFields) {
+        this.formFields = formFields;
+    }
+
 }

--- a/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/ServiceExecutePropertiesBuilder.java
+++ b/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/ServiceExecutePropertiesBuilder.java
@@ -17,7 +17,9 @@
 package com.flipkart.poseidon.serviceclients;
 
 import com.fasterxml.jackson.databind.JavaType;
+import com.flipkart.poseidon.handlers.http.multipart.FormField;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -79,6 +81,13 @@ public class ServiceExecutePropertiesBuilder {
         }
 
         instance.setServiceResponseInfoMap(serviceResponseInfoMap);
+        return this;
+    }
+
+    public ServiceExecutePropertiesBuilder setFormFields(List<FormField> formFields) {
+        if (formFields != null) {
+            instance.setFormFields(formFields);
+        }
         return this;
     }
 

--- a/service-clients-core/src/test/java/com/flipkart/poseidon/serviceclients/AbstractServiceClientTest.java
+++ b/service-clients-core/src/test/java/com/flipkart/poseidon/serviceclients/AbstractServiceClientTest.java
@@ -16,7 +16,6 @@
 
 package com.flipkart.poseidon.serviceclients;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -30,7 +29,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class AbstractServiceClientTest {
     @Test
-    public void testMultiValueParamURI() throws JsonProcessingException {
+    public void testMultiValueParamURI() {
         AbstractServiceClient serviceClient = new TestAbstractServiceClient();
         assertEquals("", serviceClient.getMultiValueParamURI("key", null));
         assertEquals("", serviceClient.getMultiValueParamURI("key", Arrays.asList()));
@@ -41,9 +40,6 @@ public class AbstractServiceClientTest {
         assertEquals("key=a&key=&key=c", serviceClient.getMultiValueParamURI("key", Arrays.asList("a", "", "c")));
         assertEquals("key=a&key=b%26c&key=c", serviceClient.getMultiValueParamURI("key", Arrays.asList("a", "b&c", "c")));
         assertEquals("key=10&key=20&key=30", serviceClient.getMultiValueParamURI("key", Arrays.asList(10, 20, 30)));
-        assertEquals("path", serviceClient.encodePathParam("path"));
-        assertEquals("path%20param", serviceClient.encodePathParam("path param"));
-        assertEquals("path+param", serviceClient.encodePathParam("path+param"));
     }
 
     public static class TestAbstractServiceClient extends AbstractServiceClient {

--- a/service-clients-core/src/test/java/com/flipkart/poseidon/serviceclients/AbstractServiceClientTest.java
+++ b/service-clients-core/src/test/java/com/flipkart/poseidon/serviceclients/AbstractServiceClientTest.java
@@ -16,10 +16,10 @@
 
 package com.flipkart.poseidon.serviceclients;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class AbstractServiceClientTest {
     @Test
-    public void testMultiValueParamURI() {
+    public void testMultiValueParamURI() throws JsonProcessingException {
         AbstractServiceClient serviceClient = new TestAbstractServiceClient();
         assertEquals("", serviceClient.getMultiValueParamURI("key", null));
         assertEquals("", serviceClient.getMultiValueParamURI("key", Arrays.asList()));
@@ -41,6 +41,9 @@ public class AbstractServiceClientTest {
         assertEquals("key=a&key=&key=c", serviceClient.getMultiValueParamURI("key", Arrays.asList("a", "", "c")));
         assertEquals("key=a&key=b%26c&key=c", serviceClient.getMultiValueParamURI("key", Arrays.asList("a", "b&c", "c")));
         assertEquals("key=10&key=20&key=30", serviceClient.getMultiValueParamURI("key", Arrays.asList(10, 20, 30)));
+        assertEquals("path", serviceClient.encodePathParam("path"));
+        assertEquals("path%20param", serviceClient.encodePathParam("path param"));
+        assertEquals("path+param", serviceClient.encodePathParam("path+param"));
     }
 
     public static class TestAbstractServiceClient extends AbstractServiceClient {

--- a/service-clients-gen/pom.xml
+++ b/service-clients-gen/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0-SNAPSHOT</version>
+        <version>5.9.0</version>
     </parent>
 
     <artifactId>service-clients-gen</artifactId>

--- a/service-clients-gen/pom.xml
+++ b/service-clients-gen/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.9.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-clients-gen</artifactId>

--- a/service-clients-gen/pom.xml
+++ b/service-clients-gen/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>5.11.0-SNAPSHOT</version>
+        <version>5.11.0</version>
     </parent>
 
     <artifactId>service-clients-gen</artifactId>

--- a/service-clients-gen/pom.xml
+++ b/service-clients-gen/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.flipkart.poseidon</groupId>
         <artifactId>poseidon</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-clients-gen</artifactId>

--- a/service-clients-gen/src/main/java/com/flipkart/poseidon/serviceclients/generator/ServiceGenerator.java
+++ b/service-clients-gen/src/main/java/com/flipkart/poseidon/serviceclients/generator/ServiceGenerator.java
@@ -324,10 +324,10 @@ public class ServiceGenerator {
                     arg = listElementVarName;
                 }
                 if (parameter.getType().equals("String")) {
-                    invocation.arg(JExpr.invoke("encodePathParam").arg(JExpr.ref(arg)));
+                    invocation.arg(JExpr.invoke("encodeUrl").arg(JExpr.ref(arg)));
                 } else if (parameter.getType().endsWith("[]")) {
                     JExpression joinerExpression = jCodeModel.ref(Joiner.class).staticInvoke("on").arg(JExpr.lit(',')).invoke("join").arg(JExpr.ref(arg));
-                    invocation.arg(JExpr.invoke("encodePathParam").arg(joinerExpression));
+                    invocation.arg(JExpr.invoke("encodeUrl").arg(joinerExpression));
                 } else if (parameter.getType().startsWith("java.util.List")) {
                     invocation.arg(jCodeModel.ref(StringUtils.class).staticInvoke("join").arg(JExpr.ref(arg)).arg(","));
                 } else {

--- a/service-clients-gen/src/main/java/com/flipkart/poseidon/serviceclients/generator/ServiceGenerator.java
+++ b/service-clients-gen/src/main/java/com/flipkart/poseidon/serviceclients/generator/ServiceGenerator.java
@@ -384,7 +384,6 @@ public class ServiceGenerator {
             }
             JClass formFieldListClass = jCodeModel.ref(List.class).narrow(FormField.class);
             block.decl(formFieldListClass, "formFields", invocation);
-            //TODO consider multivalue etc.
         }
 
         if (!argsListQueryParams.isEmpty()) {

--- a/service-clients-gen/src/main/java/com/flipkart/poseidon/serviceclients/idl/pojo/Parameter.java
+++ b/service-clients-gen/src/main/java/com/flipkart/poseidon/serviceclients/idl/pojo/Parameter.java
@@ -16,6 +16,8 @@
 
 package com.flipkart.poseidon.serviceclients.idl.pojo;
 
+import org.apache.http.entity.ContentType;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -31,6 +33,8 @@ public class Parameter {
     private String name;
     private boolean multiValue = false;
     private Boolean optional = false;
+    private Type formFieldType;
+    private String formFieldContentType = ContentType.TEXT_PLAIN.getMimeType();
     private String[] description;
 
     public String getType() {
@@ -102,5 +106,26 @@ public class Parameter {
             return false;
         }
         return true;
+    }
+
+    public String getFormFieldContentType() {
+        return formFieldContentType;
+    }
+
+    public void setFormFieldContentType(String formFieldContentType) {
+        this.formFieldContentType = formFieldContentType;
+    }
+
+    public Type getFormFieldType() {
+        return formFieldType;
+    }
+
+    public void setFormFieldType(Type formFieldType) {
+        this.formFieldType = formFieldType;
+    }
+
+    public enum Type {
+        TEXT,
+        FILE
     }
 }

--- a/service-clients-gen/src/main/resources/ServiceJsonSchema.json
+++ b/service-clients-gen/src/main/resources/ServiceJsonSchema.json
@@ -69,6 +69,15 @@
             "multiValue": {
               "type": "boolean"
             },
+            "formFieldType": {
+              "enum": [
+                "TEXT",
+                "FILE"
+              ]
+            },
+            "formFieldContentType": {
+              "type": "string"
+            },
             "description": {
               "$ref": "#/definitions/stringArray"
             }


### PR DESCRIPTION
Added support for multipart request data for service clients. This includes:
1. Generating the service client code to accept multipart params which includes file with file name.
2. Passing and Building the multipart request entity using the form fields to the place where the actual Http client call is made.

Sample service client code generated:
/**
     * Create user
     * 
     * @param userData
     *     User details as json string
     * @param avatar
     *     User's display picture
     * @return
     *     {@link FutureTaskResultToDomainObjectPromiseWrapper }{@code <}{@link User }{@code >}
     */
    @Override
    public FutureTaskResultToDomainObjectPromiseWrapper<User> createUser(
        @NotNull
        String userData,
        @NotNull
        byte[] avatar,
        @NotNull
        String avatarFileName)
        throws Exception
    {
        String uri = "/users";
        Validate.notEmpty(userData, "userData can not be null/empty");
        Validate.isTrue(ArrayUtils.isNotEmpty(avatar), "avatar can not be null/empty");
        List<FormField> formFields = Arrays.asList(new FormField("userData", ContentType.parse("application/json"), userData), new FileFormField("avatar", ContentType.parse("image/jpeg"), avatar, avatarFileName));
        Map<String, String> headersMap = new HashMap<String, String>();
        headersMap.put("Content-Type", "multipart/form-data");
        return execute(new ServiceExecutePropertiesBuilder().setJavaType(getJavaType(User.class)).setUri(uri).setHttpMethod("POST").setHeadersMap(headersMap).setFormFields(formFields).build());
    }