### PR TITLE
Disabled Intern Cache Flag to Abstract service client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.flipkart.poseidon</groupId>
     <artifactId>poseidon</artifactId>
-    <version>5.11.0-SNAPSHOT-SNAPSHOT</version>
+    <version>5.11.0-SNAPSHOT</version>
 
     <name>Poseidon</name>
     <description>A platform to build API applications that have to aggregate data from distributed services in an efficient way</description>

--- a/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/AbstractServiceClient.java
+++ b/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/AbstractServiceClient.java
@@ -16,8 +16,10 @@
 
 package com.flipkart.poseidon.serviceclients;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.core.util.InternCache;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,6 +57,7 @@ public abstract class AbstractServiceClient implements ServiceClient {
 
     static {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        objectMapper.getFactory().configure(JsonFactory.Feature.INTERN_FIELD_NAMES, false);
     }
 
     protected Map<String, Class<? extends ServiceClientException>> exceptions = new HashMap<>();

--- a/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/ServiceResponseDecoder.java
+++ b/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/ServiceResponseDecoder.java
@@ -62,7 +62,6 @@ public class ServiceResponseDecoder<T> implements HttpResponseDecoder<ServiceRes
         this.logger = logger;
         this.serviceResponseInfoMap.putAll(serviceResponseInfoMap);
         this.collectedHeaders = collectedHeaders;
-        this.objectMapper.getFactory().configure(JsonFactory.Feature.INTERN_FIELD_NAMES, false);
     }
 
     private Map<String, String> getHeaders(HttpResponse httpResponse) {


### PR DESCRIPTION
Moved disable intern cache flag to AbstractServiceClient from ServiceResponseDecoder.