### PR TITLE
Making response headers access case insensitive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.flipkart.poseidon</groupId>
     <artifactId>poseidon</artifactId>
-    <version>5.14.1</version>
+    <version>5.14.2-SNAPSHOT</version>
 
     <name>Poseidon</name>
     <description>A platform to build API applications that have to aggregate data from distributed services in an efficient way</description>

--- a/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/ServiceContext.java
+++ b/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/ServiceContext.java
@@ -44,7 +44,7 @@ public class ServiceContext {
     private static final ThreadLocal<Boolean> isDebug = ThreadLocal.withInitial(() -> false);
 
     private static final ThreadLocal<Map<String, List<ServiceDebug>>> debugResponses = ThreadLocal.withInitial(ConcurrentHashMap::new);
-    private static final ThreadLocal<Map<String, Queue<String>>> collectedHeaders = ThreadLocal.withInitial(HashMap::new);
+    private static final ThreadLocal<Map<String, Queue<String>>> collectedHeaders = ThreadLocal.withInitial(() -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
 
     /**
      * initialize an empty service context, it will cleanup previous value of the threadlocal if used in a threadpool

--- a/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/ServiceResponse.java
+++ b/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/ServiceResponse.java
@@ -19,6 +19,7 @@ package com.flipkart.poseidon.serviceclients;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Created by venkata.lakshmi on 30/03/15.
@@ -35,12 +36,14 @@ public class ServiceResponse<T> {
     public ServiceResponse(T data, Map<String, String> headers) {
         this.isSuccess = true;
         this.dataList.add(data);
-        this.headers = headers;
+        this.headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        headers.forEach((k,v) -> this.headers.put(k,v));
     }
 
     public ServiceResponse(ServiceClientException e, Map<String, String> headers) {
         this.exception = e;
-        this.headers = headers;
+        this.headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        headers.forEach((k,v) -> this.headers.put(k,v));
     }
 
     public void addData(List<T> data) {

--- a/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/ServiceResponseDecoder.java
+++ b/service-clients-core/src/main/java/com/flipkart/poseidon/serviceclients/ServiceResponseDecoder.java
@@ -64,7 +64,7 @@ public class ServiceResponseDecoder<T> implements HttpResponseDecoder<ServiceRes
     }
 
     private Map<String, String> getHeaders(HttpResponse httpResponse) {
-        Map<String, String> headers = new HashMap<>();
+        Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         Header[] responseHeaders = httpResponse.getAllHeaders();
         if (responseHeaders == null || responseHeaders.length == 0) {
             return headers;

--- a/service-clients-core/src/test/java/com/flipkart/poseidon/serviceclients/ServiceResponseTest.java
+++ b/service-clients-core/src/test/java/com/flipkart/poseidon/serviceclients/ServiceResponseTest.java
@@ -49,4 +49,14 @@ public class ServiceResponseTest {
         assertTrue(response.getDataList().isEmpty());
     }
 
+    @Test
+    public void testCaseInsensitiveGetHeader() throws Exception {
+        ServiceResponse<String> response = new ServiceResponse<>("string", new HashMap<String, String>() {{
+            put("heAder1", "value1");
+        }});
+        assertEquals("value1", response.getHeaders().get("Header1"));
+        assertEquals("value1", response.getHeaders().get("header1"));
+        assertEquals("value1", response.getHeaders().get("hEader1"));
+    }
+
 }


### PR DESCRIPTION
Converting Concrete class of headers to Case Insensitive TreeMap.
Caveats: null value will not be supported in key now, which in the first, should not be allowed in headers.